### PR TITLE
12 Definir público-alvo do formulário

### DIFF
--- a/backend/Formify/Formify.Server/Controllers/FormsController.cs
+++ b/backend/Formify/Formify.Server/Controllers/FormsController.cs
@@ -37,6 +37,7 @@ namespace Formify.Server.Controllers
                 Id = allForms.Any() ? allForms.Max(f => f.Id) + 1 : 1,
                 Title = request.Title.Trim(),
                 Description = request.Description?.Trim(),
+                Audience = request.Audience,
                 StatusDrafted = request.StatusDraft,
                 CreatedAt = DateTime.Now,
                 UpdatedAt = DateTime.Now,

--- a/backend/Formify/Formify.Server/DTOs/CreateFormRequest.cs
+++ b/backend/Formify/Formify.Server/DTOs/CreateFormRequest.cs
@@ -12,6 +12,8 @@ namespace Formify.Server.DTOs
         [MaxLength(1000, ErrorMessage = "A descrição não pode ter mais de 1000 caracteres.")]
         public string? Description { get; set; }
 
+        public List<string> Audience { get; set; } = new();
+
         public bool StatusDraft { get; set; } = true;
         public List<Field> Fields { get; set; } = new List<Field>();
     }

--- a/backend/Formify/Formify.Server/Models/Form.cs
+++ b/backend/Formify/Formify.Server/Models/Form.cs
@@ -8,6 +8,8 @@ namespace Formify.Server.Models
 
         public string? Description { get; set; }
 
+        public List<string> Audience { get; set; } = new();
+
         public bool StatusDrafted { get; set; }
 
         public List<Field> Fields { get; set; } = new List<Field>();

--- a/backend/Formify/formify.client/Schema/FormsList.json
+++ b/backend/Formify/formify.client/Schema/FormsList.json
@@ -3,6 +3,7 @@
     "Id": 1,
     "Title": "Teste com altera\u00E7\u00E3o do backend",
     "Description": "",
+    "Audience": [],
     "StatusDrafted": false,
     "Fields": [
       {
@@ -21,6 +22,7 @@
     "Id": 2,
     "Title": "Pedro",
     "Description": "alguma coisa",
+    "Audience": [],
     "StatusDrafted": false,
     "Fields": [
       {
@@ -39,6 +41,7 @@
     "Id": 3,
     "Title": "teste",
     "Description": "teste",
+    "Audience": [],
     "StatusDrafted": false,
     "Fields": [],
     "CreatedAt": "2026-04-10T15:28:05.6871998+01:00",
@@ -48,6 +51,7 @@
     "Id": 4,
     "Title": "Rascunho",
     "Description": "Rascunho",
+    "Audience": [],
     "StatusDrafted": true,
     "Fields": [
       {
@@ -66,6 +70,7 @@
     "Id": 6,
     "Title": "Teste 2",
     "Description": "Isto s\u00E3o muitos testes para o meu gosto",
+    "Audience": [],
     "StatusDrafted": false,
     "Fields": [
       {
@@ -84,6 +89,7 @@
     "Id": 7,
     "Title": "ffkghfk",
     "Description": "kfgkg",
+    "Audience": [],
     "StatusDrafted": true,
     "Fields": [
       {
@@ -102,6 +108,7 @@
     "Id": 8,
     "Title": "Teste tarefa #71",
     "Description": "",
+    "Audience": [],
     "StatusDrafted": false,
     "Fields": [
       {
@@ -120,6 +127,7 @@
     "Id": 9,
     "Title": "Teste 2 tarefa #71",
     "Description": "",
+    "Audience": [],
     "StatusDrafted": false,
     "Fields": [
       {
@@ -138,6 +146,7 @@
     "Id": 10,
     "Title": "Teste 3 tarefa #71",
     "Description": "",
+    "Audience": [],
     "StatusDrafted": true,
     "Fields": [
       {
@@ -156,6 +165,7 @@
     "Id": 11,
     "Title": "Teste 4 tarefa #71",
     "Description": "",
+    "Audience": [],
     "StatusDrafted": false,
     "Fields": [
       {
@@ -174,6 +184,7 @@
     "Id": 12,
     "Title": "Teste tarefa #69",
     "Description": "",
+    "Audience": [],
     "StatusDrafted": false,
     "Fields": [
       {
@@ -196,6 +207,7 @@
     "Id": 13,
     "Title": "teste",
     "Description": "",
+    "Audience": [],
     "StatusDrafted": true,
     "Fields": [
       {
@@ -222,9 +234,55 @@
     "Id": 14,
     "Title": "Teste com P\u00FAblico Alvo",
     "Description": "",
+    "Audience": [],
     "StatusDrafted": false,
     "Fields": [],
     "CreatedAt": "2026-04-16T20:10:34.8758257+01:00",
     "UpdatedAt": "2026-04-16T20:10:34.8758273+01:00"
+  },
+  {
+    "Id": 15,
+    "Title": "Testar associa\u00E7\u00E3o do p\u00FAblico-alvo",
+    "Description": "",
+    "Audience": [],
+    "StatusDrafted": false,
+    "Fields": [
+      {
+        "Id": "1776367596723",
+        "Type": "number",
+        "Label": "Endere\u00E7o",
+        "Required": true,
+        "Placeholder": "",
+        "Options": []
+      }
+    ],
+    "CreatedAt": "2026-04-16T20:27:28.2627762+01:00",
+    "UpdatedAt": "2026-04-16T20:27:28.2627777+01:00"
+  },
+  {
+    "Id": 16,
+    "Title": "teste",
+    "Description": "",
+    "Audience": [
+      "staff",
+      "teacher"
+    ],
+    "StatusDrafted": false,
+    "Fields": [],
+    "CreatedAt": "2026-04-16T20:32:57.261738+01:00",
+    "UpdatedAt": "2026-04-16T20:32:57.26174+01:00"
+  },
+  {
+    "Id": 17,
+    "Title": "teste",
+    "Description": "",
+    "Audience": [
+      "teacher",
+      "staff"
+    ],
+    "StatusDrafted": false,
+    "Fields": [],
+    "CreatedAt": "2026-04-16T20:36:13.3476495+01:00",
+    "UpdatedAt": "2026-04-16T20:36:13.3476762+01:00"
   }
 ]

--- a/backend/Formify/formify.client/Schema/FormsList.json
+++ b/backend/Formify/formify.client/Schema/FormsList.json
@@ -191,5 +191,40 @@
     ],
     "CreatedAt": "2026-04-14T14:54:11.1764946+01:00",
     "UpdatedAt": "2026-04-14T14:54:11.1764996+01:00"
+  },
+  {
+    "Id": 13,
+    "Title": "teste",
+    "Description": "",
+    "StatusDrafted": true,
+    "Fields": [
+      {
+        "Id": "1776363291381",
+        "Type": "text",
+        "Label": "",
+        "Required": false,
+        "Placeholder": "",
+        "Options": []
+      },
+      {
+        "Id": "1776363304430",
+        "Type": "text",
+        "Label": "",
+        "Required": false,
+        "Placeholder": "",
+        "Options": []
+      }
+    ],
+    "CreatedAt": "2026-04-16T19:17:17.4679527+01:00",
+    "UpdatedAt": "2026-04-16T19:17:17.4679574+01:00"
+  },
+  {
+    "Id": 14,
+    "Title": "Teste com P\u00FAblico Alvo",
+    "Description": "",
+    "StatusDrafted": false,
+    "Fields": [],
+    "CreatedAt": "2026-04-16T20:10:34.8758257+01:00",
+    "UpdatedAt": "2026-04-16T20:10:34.8758273+01:00"
   }
 ]

--- a/backend/Formify/formify.client/src/pages/CreateForm.jsx
+++ b/backend/Formify/formify.client/src/pages/CreateForm.jsx
@@ -33,6 +33,10 @@ export default function CreateForm() {
         // Atualiza o estado adicionando o novo campo à lista existente
         setFields([...fields, novoCampo]);
     };
+    const eliminarCampo = (id) => {
+        const novosCampos = fields.filter(campo => campo.id !== id);
+        setFields(novosCampos);
+    };
 
     // Função que altera o label (nome visível) de um campo específico
     const alterarLabel = (id, novoLabel) => {
@@ -233,16 +237,7 @@ export default function CreateForm() {
                                 <span>Funcionários</span>
                             </label>
 
-                            {/* Ambos */}
-                            <label className="flex items-center gap-2 cursor-pointer text-sm">
-                                <input
-                                    type="checkbox"
-                                    checked={audience.includes("both")}
-                                    onChange={() => toggleAudience("both")}
-                                    className="h-4 w-4 accent-blue-600"
-                                />
-                                <span>Ambos</span>
-                            </label>
+                            
                             {erroAudience && (
                             <span className="text-red-500 text-sm">
                                 {erroAudience}
@@ -274,6 +269,7 @@ export default function CreateForm() {
                                 <input
                                     type="text"
                                     value={campo.label}
+                                    placeholder="Ex: Endereço ..."
                                     onChange={(e) => alterarLabel(campo.id, e.target.value)}
                                     className="rounded-md border p-2"
                                 />
@@ -332,8 +328,18 @@ export default function CreateForm() {
                                 />
                                 Campo obrigatório
                             </label>
+                            <div className="flex justify-end mt-2">
+                                <button
+                                    type="button"
+                                    onClick={() => eliminarCampo(campo.id)}
+                                    className="flex items-center gap-2 rounded-md border border-red-200 bg-red-50 px-3 py-1 text-sm font-medium text-red-600 transition-all hover:bg-red-100 hover:border-red-300"
+                                >
+                                    🗑️ Eliminar campo
+                                </button>
+                            </div>
 
                         </div>
+
                     ))}
 
                     <div className="mt-6 flex justify-end gap-4 border-t border-accent-border pt-4">

--- a/backend/Formify/formify.client/src/pages/CreateForm.jsx
+++ b/backend/Formify/formify.client/src/pages/CreateForm.jsx
@@ -7,10 +7,13 @@ export default function CreateForm() {
     const [descricao, setDescricao] = useState('');
     // Estado que guarda a lista de campos do formulário (cada campo tem label, tipo, etc.)
     const [fields, setFields] = useState([]); // comentario ju
+    const [audience, setAudience] = useState([]);
 
     // estado para guardar mensagens de erro do campo nome
     const [erroNome, setErroNome] = useState('');
     const [erroDescricao, setErroDescricao] = useState('');
+    // Limpa qualquer erro anterior do público-alvo
+    const [erroAudience, setErroAudience] = useState('');
 
     //state hook para prevenir double-submits
     const [isLoading, setIsLoading] = useState(false);
@@ -62,6 +65,14 @@ export default function CreateForm() {
         setFields(novosCampos);
     };
 
+    const toggleAudience = (value) => {
+        setAudience(prev =>
+            prev.includes(value)
+                ? prev.filter(v => v !== value)
+                : [...prev, value]
+        );
+    };
+
      // Função que altera as opções de um campo dropdown específico
     const alterarOptions = (id, novasOptions) => {
         const listaOptions = novasOptions
@@ -82,6 +93,7 @@ export default function CreateForm() {
         setIsLoading(true); // Desativa o botão
         setErroNome('');
         setErroDescricao('');
+        setErroAudience('');
 
         let formValido = true;
         setErroNome('');
@@ -91,11 +103,16 @@ export default function CreateForm() {
             setIsLoading(false);
             formValido = false;
         }
+        // Validação do público-alvo
+        if (audience.length === 0) {
+            setErroAudience("Tem de selecionar pelo menos um público-alvo.");
+            setIsLoading(false);// Marca o formulário como inválido
+            formValido = false;
+            return;
+        }
 
         if (!formValido) return;
-        console.log('Campos no estado antes de enviar:', fields);
-        console.log('Título:', nome);
-        console.log('Descrição:', descricao);
+        
 
         try {
             const isFinal = e.nativeEvent.submitter.id === "save-final";
@@ -108,7 +125,8 @@ export default function CreateForm() {
                     Title: nome,
                     Description: descricao,
                     StatusDraft: !isFinal, // Se o botão que disparou o evento for o de "Guardar", então o form será guardado como !Draft
-                    Fields: fields // envia só os labels
+                    Fields: fields, // envia só os labels
+                    Audience: audience
                 }),
             });
 
@@ -186,6 +204,55 @@ export default function CreateForm() {
                         />
                         {erroDescricao && <span className="text-red-500 text-sm">{erroDescricao}</span>}
                     </div>
+                    <div className="flex flex-col gap-3">
+                        <label className="font-medium text-text-h">
+                            Público-alvo
+                        </label>
+
+                        <div className="flex flex-col gap-2 rounded-md border border-accent-border bg-white p-3">
+
+                            {/* Professores */}
+                            <label className="flex items-center gap-2 cursor-pointer text-sm">
+                                <input
+                                    type="checkbox"
+                                    checked={audience.includes("teacher")}
+                                    onChange={() => toggleAudience("teacher")}
+                                    className="h-4 w-4 accent-blue-600"
+                                />
+                                <span>Professores</span>
+                            </label>
+
+                            {/* Funcionários */}
+                            <label className="flex items-center gap-2 cursor-pointer text-sm">
+                                <input
+                                    type="checkbox"
+                                    checked={audience.includes("staff")}
+                                    onChange={() => toggleAudience("staff")}
+                                    className="h-4 w-4 accent-blue-600"
+                                />
+                                <span>Funcionários</span>
+                            </label>
+
+                            {/* Ambos */}
+                            <label className="flex items-center gap-2 cursor-pointer text-sm">
+                                <input
+                                    type="checkbox"
+                                    checked={audience.includes("both")}
+                                    onChange={() => toggleAudience("both")}
+                                    className="h-4 w-4 accent-blue-600"
+                                />
+                                <span>Ambos</span>
+                            </label>
+                            {erroAudience && (
+                            <span className="text-red-500 text-sm">
+                                {erroAudience}
+                            </span>
+                        )}
+                        </div>
+                        
+                    </div>
+                    
+                    
                     {/* Botão que permite adicionar novos campos ao formulário */}
                     <div className="mt-4">
                         <button


### PR DESCRIPTION
 Adicionado a seleção de público-alvo (professores, funcionários ou ambos) e a persistência da restrição. Realizados testes e funcionalidade de remoção de campos no formulário. 