### PR TITLE
fix: corrigir drag and drop do editor de formularios

### DIFF
--- a/backend/Formify/formify.client/src/pages/CreateForm.jsx
+++ b/backend/Formify/formify.client/src/pages/CreateForm.jsx
@@ -377,7 +377,17 @@ function EditPanel({ field, onClose, onUpdate }) {
 
 // ─── Card de campo no canvas ──────────────────────────────────────────────────
 // Representa visualmente cada campo adicionado ao formulário.
-function FieldCard({ field, isSelected, onSelect, onRemove, isDraggingOver, onDragStart, onDragEnter, onDragOver, onDragEnd }) {
+function FieldCard({
+    field,
+    isSelected,
+    onSelect,
+    onRemove,
+    isDraggingOver,
+    onDragStart,
+    onDragOver,
+    onDrop,
+    onDragEnd,
+}) {
     const ti = getTypeInfo(field.type);
     const isSection = field.type === 'section';
     const isHalf = !isSection && (field.width || 'full') === 'half';
@@ -388,8 +398,8 @@ function FieldCard({ field, isSelected, onSelect, onRemove, isDraggingOver, onDr
             <div
                 draggable
                 onDragStart={onDragStart}
-                onDragEnter={onDragEnter}
                 onDragOver={onDragOver}
+                onDrop={onDrop}
                 onDragEnd={onDragEnd}
                 onClick={onSelect}
                 style={{ gridColumn: '1 / -1' }}
@@ -420,8 +430,8 @@ function FieldCard({ field, isSelected, onSelect, onRemove, isDraggingOver, onDr
         <div
             draggable
             onDragStart={onDragStart}
-            onDragEnter={onDragEnter}
             onDragOver={onDragOver}
+            onDrop={onDrop}
             onDragEnd={onDragEnd}
             onClick={onSelect}
             style={{ gridColumn: isHalf ? 'span 1' : '1 / -1' }}
@@ -519,11 +529,13 @@ export default function CreateForm() {
         setErroAudience('');
     };
 
-    // ── Adicionar campo ao formulário ──
-    const adicionarCampo = (type) => {
+    // ── Criar campo ──
+    // Cria a estrutura base de um campo novo, sem o adicionar ainda ao formulário.
+    // Isto permite reutilizar a mesma lógica tanto no clique como no drag and drop.
+    const criarCampo = (type) => {
         const ti = getTypeInfo(type);
 
-        const novo = {
+        return {
             id: Date.now().toString(),
             type,
             label: ti.label,
@@ -535,6 +547,12 @@ export default function CreateForm() {
             tableRows: type === 'table' ? 2 : 0,
             description: '',
         };
+    };
+
+    // ── Adicionar campo ao formulário ──
+    // Usado quando o utilizador clica num elemento da paleta.
+    const adicionarCampo = (type) => {
+        const novo = criarCampo(type);
 
         setFields(prev => [...prev, novo]);
         setSelectedId(novo.id);
@@ -555,57 +573,99 @@ export default function CreateForm() {
         }
     };
 
-    // ── Drag and drop para reordenar campos no canvas ──
-    // A reordenação acontece durante o dragEnter, tornando a troca de posição
-    // mais fluida e mais fácil de controlar pelo utilizador.
-    const handleCardDragStart = (index) => {
+    // ── Drag and drop da paleta para o canvas ──
+    // Guarda o tipo de campo que está a ser arrastado a partir da paleta.
+    const handlePaletteDragStart = (e, type) => {
+        dragTypeRef.current = type;
+        dragIndex.current = null;
+        setIsDraggingFromPalette(true);
+
+        e.dataTransfer.effectAllowed = 'copy';
+        e.dataTransfer.setData('field-type', type);
+    };
+
+    // ── Início do drag de um campo já existente ──
+    // Guarda o índice do campo que está a ser reordenado.
+    const handleCardDragStart = (e, index) => {
         dragIndex.current = index;
+        dragTypeRef.current = null;
         setDragOverIndex(index);
         setIsDraggingFromPalette(false);
+
+        e.dataTransfer.effectAllowed = 'move';
+        e.dataTransfer.setData('field-index', index.toString());
     };
 
-    const handleCardDragEnter = (index) => {
-        if (isDraggingFromPalette) return;
-        if (dragIndex.current === null) return;
-        if (dragIndex.current === index) return;
-
-        setFields(prevFields => {
-            const updatedFields = [...prevFields];
-
-            const [movedField] = updatedFields.splice(dragIndex.current, 1);
-            updatedFields.splice(index, 0, movedField);
-
-            dragIndex.current = index;
-
-            return updatedFields;
-        });
-
+    // ── Campo sobre o qual o utilizador está a passar com o rato ──
+    const handleCardDragOver = (e, index) => {
+        e.preventDefault();
         setDragOverIndex(index);
     };
 
-    const handleCardDragOver = (e) => {
+    // ── Largar em cima de um campo existente ──
+    // Permite inserir um novo campo nessa posição ou mover um campo já existente.
+    const handleCardDrop = (e, dropIndex) => {
         e.preventDefault();
-    };
+        e.stopPropagation();
 
-    const handleCardDragEnd = () => {
+        const draggedType = dragTypeRef.current || e.dataTransfer.getData('field-type');
+
+        // Caso 1: elemento vindo da paleta
+        if (draggedType) {
+            const novo = criarCampo(draggedType);
+
+            setFields(prev => {
+                const updated = [...prev];
+                updated.splice(dropIndex, 0, novo);
+                return updated;
+            });
+
+            setSelectedId(novo.id);
+            setErroFields('');
+        }
+
+        // Caso 2: reordenar campo já existente
+        else if (dragIndex.current !== null && dragIndex.current !== dropIndex) {
+            setFields(prev => {
+                const updated = [...prev];
+                const [moved] = updated.splice(dragIndex.current, 1);
+                updated.splice(dropIndex, 0, moved);
+                return updated;
+            });
+        }
+
         dragIndex.current = null;
+        dragTypeRef.current = null;
         setDragOverIndex(null);
         setIsDraggingFromPalette(false);
     };
 
+    // ── Fim do drag ──
+    const handleCardDragEnd = () => {
+        dragIndex.current = null;
+        dragTypeRef.current = null;
+        setDragOverIndex(null);
+        setIsDraggingFromPalette(false);
+    };
+
+    // ── Largar no espaço vazio do canvas ──
+    // Se o utilizador largar fora de um campo específico, adiciona ao fim.
     const handleCanvasDrop = (e) => {
         e.preventDefault();
 
-        if (isDraggingFromPalette && dragTypeRef.current) {
-            adicionarCampo(dragTypeRef.current);
+        const draggedType = dragTypeRef.current || e.dataTransfer.getData('field-type');
+
+        if (draggedType) {
+            adicionarCampo(draggedType);
         }
 
+        dragIndex.current = null;
         dragTypeRef.current = null;
-        setIsDraggingFromPalette(false);
         setDragOverIndex(null);
+        setIsDraggingFromPalette(false);
     };
 
-   // ── Submissão do formulário ──
+    // ── Submissão do formulário ──
     // Valida os dados no frontend antes de enviar para o backend.
     const handleSubmit = async (e) => {
         e.preventDefault();
@@ -785,7 +845,7 @@ export default function CreateForm() {
                                 <div
                                     key={ft.type}
                                     draggable
-                                    onDragStart={() => handlePaletteDragStart(ft.type)}
+                                    onDragStart={(e) => handlePaletteDragStart(e, ft.type)}
                                     onDragEnd={() => setIsDraggingFromPalette(false)}
                                     onClick={() => adicionarCampo(ft.type)}
                                     className="flex items-center gap-2 rounded-md border border-gray-200 bg-white px-2.5 py-1.5 text-xs text-gray-700 cursor-grab active:cursor-grabbing hover:border-green-300 hover:bg-green-50 transition-all select-none"
@@ -824,20 +884,20 @@ export default function CreateForm() {
                                 <div className="grid gap-3" style={{ gridTemplateColumns: '1fr 1fr' }}>
                                     {fields.map((campo, index) => (
                                         <FieldCard
-    key={campo.id}
-    field={campo}
-    isSelected={selectedId === campo.id}
-    onSelect={(e) => {
-        e?.stopPropagation();
-        setSelectedId(campo.id);
-    }}
-    onRemove={() => removerCampo(campo.id)}
-    isDraggingOver={dragOverIndex === index && !isDraggingFromPalette}
-    onDragStart={() => handleCardDragStart(index)}
-    onDragEnter={() => handleCardDragEnter(index)}
-    onDragOver={handleCardDragOver}
-    onDragEnd={handleCardDragEnd}
-/>
+                                            key={campo.id}
+                                            field={campo}
+                                            isSelected={selectedId === campo.id}
+                                            onSelect={(e) => {
+                                                e?.stopPropagation();
+                                                setSelectedId(campo.id);
+                                            }}
+                                            onRemove={() => removerCampo(campo.id)}
+                                            isDraggingOver={dragOverIndex === index}
+                                            onDragStart={(e) => handleCardDragStart(e, index)}
+                                            onDragOver={(e) => handleCardDragOver(e, index)}
+                                            onDrop={(e) => handleCardDrop(e, index)}
+                                            onDragEnd={handleCardDragEnd}
+                                        />
                                     ))}
                                 </div>
                             )}


### PR DESCRIPTION
Este PR corrige o comportamento do drag and drop no editor visual de formulários.

Alterações:
- Corrige o arrastar de elementos da paleta para o canvas;
- Torna a reordenação dos campos mais estável e previsível;
- Mantém a persistência da ordem através da propriedade Order.

Related to #67