### PR TITLE
feat: alinhar ViewForm com editor e separar sidebar por papel

### DIFF
--- a/backend/Formify/formify.client/src/components/Layout/Sidebar.jsx
+++ b/backend/Formify/formify.client/src/components/Layout/Sidebar.jsx
@@ -1,40 +1,80 @@
-import { Link } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 
 /**
  * Sidebar Component
- * 
+ *
  * Navegação lateral principal da aplicação.
+ * Os itens do menu mudam consoante a rota:
+ *  - Rotas de utilizador (/funcionario, /professor) → menu de utilizador
+ *  - Restantes rotas → menu de administração
  */
 export default function Sidebar() {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const path = location.pathname.toLowerCase();
+  const isFuncionario = path.startsWith('/funcionario');
+  const isProfessor = path.startsWith('/professor');
+  const isUserView = isFuncionario || isProfessor;
+
+  const linkCls =
+    'block rounded-lg px-4 py-2 text-sm font-medium text-text transition-colors hover:bg-accent-bg hover:text-accent';
+  const buttonCls =
+    'block w-full text-left rounded-lg px-4 py-2 text-sm font-medium text-text transition-colors hover:bg-accent-bg hover:text-accent';
+
+  // Placeholder enquanto não existe sistema de autenticação real.
+  const handleFakeAction = (label) => {
+    alert(`${label}: funcionalidade em desenvolvimento.`);
+  };
+
+  const handleLogout = () => {
+    alert('Sessão terminada (mock).');
+    navigate('/');
+  };
+
   return (
     <aside className="w-64 border-r-2 border-black bg-white px-4 py-6">
       <div className="mb-6 border-b border-black pb-4">
-              <h1 className="text-2xl font-bold text-accent text-center">Formify</h1>
+        <h1 className="text-2xl font-bold text-accent text-center">Formify</h1>
       </div>
 
       <nav className="space-y-2">
-        <Link
-          to="/"
-          className="block rounded-lg px-4 py-2 text-sm font-medium text-text transition-colors hover:bg-accent-bg hover:text-accent"
-        >
-         Formulários
-        </Link>
-
-       <Link
-        to="/DraftedForms"
-        className="block rounded-lg px-4 py-2 text-sm font-medium text-text transition-colors hover:bg-accent-bg hover:text-accent"
-       >
-         Formulários em Rascunho
-       </Link>
-
-       <Link
-        to="/CreateForm"
-        className="block rounded-lg px-4 py-2 text-sm font-medium text-text transition-colors hover:bg-accent-bg hover:text-accent"
-       >
-        Criar Formulário
-       </Link>
-
-
+        {isUserView ? (
+          <>
+            <Link to={isFuncionario ? '/funcionario' : '/professor'} className={linkCls}>
+              Formulários
+            </Link>
+            <button
+              type="button"
+              onClick={() => handleFakeAction('Formulários Preenchidos')}
+              className={buttonCls}
+            >
+              Formulários Preenchidos
+            </button>
+            <button
+              type="button"
+              onClick={() => handleFakeAction('Informações Pessoais')}
+              className={buttonCls}
+            >
+              Informações Pessoais
+            </button>
+            <button type="button" onClick={handleLogout} className={buttonCls}>
+              Logout
+            </button>
+          </>
+        ) : (
+          <>
+            <Link to="/" className={linkCls}>
+              Formulários
+            </Link>
+            <Link to="/DraftedForms" className={linkCls}>
+              Formulários em Rascunho
+            </Link>
+            <Link to="/CreateForm" className={linkCls}>
+              Criar Formulário
+            </Link>
+          </>
+        )}
       </nav>
     </aside>
   );

--- a/backend/Formify/formify.client/src/pages/ViewForm.jsx
+++ b/backend/Formify/formify.client/src/pages/ViewForm.jsx
@@ -31,29 +31,19 @@ function FieldReadOnly({ field }) {
             return <input disabled type="text" placeholder={field.placeholder} className={inputCls} />;
 
         case 'textarea':
-            return <textarea disabled placeholder={field.placeholder} rows={3} className={`${inputCls} resize-none`} />;
+            return <textarea disabled placeholder={field.placeholder} rows={2} className={`${inputCls} resize-none`} />;
 
         case 'number':
-            return <input disabled type="number" placeholder="0" className={inputCls} />;
+            return <input disabled type="number" placeholder={field.placeholder || '0'} className={inputCls} />;
 
         case 'date':
             return <input disabled type="date" className={inputCls} />;
 
         case 'dropdown':
             return (
-                <select
-                    className={`${inputCls} cursor-default`} // Removemos o 'cursor-not-allowed' para o utilizador saber que pode clicar
-                    defaultValue=""
-                    // Impede qualquer mudança de valor se o utilizador tentar forçar via teclado
-                    onChange={(e) => e.preventDefault()}
-                >
-                    <option value="" disabled hidden>
-                        {field.placeholder || 'Clique para ver as opções...'}
-                    </option>
-                    {field.options?.map((o, i) => (
-                        <option key={i} disabled className="text-gray-400">
-                            {o}
-                        </option>
+                <select disabled className={inputCls}>
+                    {(field.options?.length ? field.options : ['Opção 1', 'Opção 2']).map((o, i) => (
+                        <option key={i}>{o}</option>
                     ))}
                 </select>
             );
@@ -72,7 +62,7 @@ function FieldReadOnly({ field }) {
             );
 
         case 'table': {
-            const cols = field.tableColumns?.length ? field.tableColumns : ['Coluna A', 'Coluna B'];
+            const cols = field.tableColumns?.length ? field.tableColumns : ['Coluna A', 'Coluna B', 'Coluna C'];
             return (
                 <div className="overflow-x-auto rounded border border-gray-100">
                     <table className="w-full border-collapse text-xs">
@@ -86,7 +76,7 @@ function FieldReadOnly({ field }) {
                             </tr>
                         </thead>
                         <tbody>
-                            {Array.from({ length: field.tableRows || 1 }).map((_, r) => (
+                            {Array.from({ length: field.tableRows || 2 }).map((_, r) => (
                                 <tr key={r}>
                                     {cols.map((_, i) => (
                                         <td key={i} className="border-b border-gray-100 px-3 py-2 text-gray-300">—</td>
@@ -190,7 +180,7 @@ export default function FormViewer() {
                                     <div className="h-px w-full bg-gray-100" />
                                 </div>
                                 {field.description && (
-                                    <p className="text-xs text-gray-400 mt-1">{field.description}</p>
+                                    <p className="mt-1 text-center text-xs text-gray-400">{field.description}</p>
                                 )}
                             </div>
                         );


### PR DESCRIPTION
- ViewForm: usar field.placeholder em number, remover opção fantasma do dropdown, alinhar rows do textarea, centrar descrição de secção e harmonizar defaults da tabela (3 colunas, 2 linhas) para garantir correspondência total com o editor.
- Sidebar: detetar /funcionario e /professor via useLocation e mostrar menu de utilizador (Formulários, Formulários Preenchidos, Informações Pessoais, Logout). Ações fake via alert() até existir autenticação.

Ref #89