### PR TITLE
feat: criar página "Os Meus Formulários" para histórico de submissões (#135)

### DIFF
--- a/backend/Formify/Formify.Server/Controllers/SubmissionsController.cs
+++ b/backend/Formify/Formify.Server/Controllers/SubmissionsController.cs
@@ -1,0 +1,101 @@
+using Formify.Server.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace Formify.Server.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    public class SubmissionsController : ControllerBase
+    {
+        private readonly JsonHandler _jsonHandler;
+
+        public SubmissionsController(JsonHandler jsonHandler)
+        {
+            _jsonHandler = jsonHandler;
+        }
+
+        // GET /api/submissions/me
+        // Lista as submissões do utilizador autenticado com informação básica
+        // do formulário associado (título e descrição) para apresentação na UI.
+        [HttpGet("me")]
+        public async Task<IActionResult> GetMySubmissions()
+        {
+            if (!TryGetUserId(out int userId))
+            {
+                return Unauthorized(new { message = "Utilizador não autenticado ou token inválido." });
+            }
+
+            var allSubmissions = await _jsonHandler.GetAllSubmissionsAsync();
+            var allForms = await _jsonHandler.GetAllFormsAsync();
+
+            var mySubmissions = allSubmissions
+                .Where(s => s.UserId == userId)
+                .OrderByDescending(s => s.SubmittedAt)
+                .Select(s =>
+                {
+                    var form = allForms.FirstOrDefault(f => f.Id == s.FormId);
+                    return new
+                    {
+                        id = s.Id,
+                        formId = s.FormId,
+                        formTitle = form?.Title ?? "(Formulário removido)",
+                        formDescription = form?.Description,
+                        submittedAt = s.SubmittedAt,
+                        status = "Submetido"
+                    };
+                })
+                .ToList();
+
+            return Ok(mySubmissions);
+        }
+
+        // GET /api/submissions/me/{id}
+        // Detalhe de uma submissão própria. Devolve a submissão completa e o
+        // formulário associado para que a UI consiga mostrar perguntas + respostas.
+        [HttpGet("me/{id}")]
+        public async Task<IActionResult> GetMySubmissionDetail(string id)
+        {
+            if (!TryGetUserId(out int userId))
+            {
+                return Unauthorized(new { message = "Utilizador não autenticado ou token inválido." });
+            }
+
+            var allSubmissions = await _jsonHandler.GetAllSubmissionsAsync();
+            var submission = allSubmissions.FirstOrDefault(s => s.Id == id);
+
+            if (submission == null)
+            {
+                return NotFound(new { message = "Submissão não encontrada." });
+            }
+
+            // Bloqueio explícito: o utilizador só pode aceder às suas próprias submissões.
+            if (submission.UserId != userId)
+            {
+                return StatusCode(403, new { message = "Acesso negado a esta submissão." });
+            }
+
+            var allForms = await _jsonHandler.GetAllFormsAsync();
+            var form = allForms.FirstOrDefault(f => f.Id == submission.FormId);
+
+            return Ok(new
+            {
+                id = submission.Id,
+                formId = submission.FormId,
+                submittedAt = submission.SubmittedAt,
+                status = "Submetido",
+                answers = submission.Answers,
+                form
+            });
+        }
+
+        private bool TryGetUserId(out int userId)
+        {
+            userId = 0;
+            var claim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            return !string.IsNullOrEmpty(claim) && int.TryParse(claim, out userId);
+        }
+    }
+}

--- a/backend/Formify/formify.client/src/App.jsx
+++ b/backend/Formify/formify.client/src/App.jsx
@@ -10,6 +10,8 @@ import ProfessorDashboard from './pages/Professor/ProfessorDashboard';
 import FuncionarioDashboard from './pages/Funcionario/FuncionarioDashboard';
 import ProtectedRoute from './components/Auth/ProtectedRoute';
 import RespondForm from './pages/RespondForm';
+import MySubmissions from './pages/MySubmissions';
+import MySubmissionDetail from './pages/MySubmissionDetail';
 
 export default function App() {
     return (
@@ -35,6 +37,17 @@ export default function App() {
                     <Route path="/respond/:id" element={
                         <ProtectedRoute allowedRoles={["professor", "funcionario"]}>
                             <RespondForm />
+                        </ProtectedRoute>
+                    } />
+
+                    <Route path="/meus-formularios" element={
+                        <ProtectedRoute allowedRoles={["professor", "funcionario"]}>
+                            <MySubmissions />
+                        </ProtectedRoute>
+                    } />
+                    <Route path="/meus-formularios/:id" element={
+                        <ProtectedRoute allowedRoles={["professor", "funcionario"]}>
+                            <MySubmissionDetail />
                         </ProtectedRoute>
                     } />
                 </Routes>

--- a/backend/Formify/formify.client/src/components/Layout/Sidebar.jsx
+++ b/backend/Formify/formify.client/src/components/Layout/Sidebar.jsx
@@ -13,9 +13,11 @@ export default function Sidebar() {
   const navigate = useNavigate();
 
   const path = location.pathname.toLowerCase();
-  const isFuncionario = path.startsWith('/funcionario');
-  const isProfessor = path.startsWith('/professor');
-  const isUserView = isFuncionario || isProfessor;
+  const role = (localStorage.getItem('role') || '').toLowerCase();
+  const isFuncionario = path.startsWith('/funcionario') || role === 'funcionario';
+  const isProfessor = path.startsWith('/professor') || role === 'professor';
+  const isMyForms = path.startsWith('/meus-formularios');
+  const isUserView = isFuncionario || isProfessor || isMyForms;
 
   const linkCls =
     'block rounded-lg px-4 py-2 text-sm font-medium text-text transition-colors hover:bg-accent-bg hover:text-accent';
@@ -49,13 +51,9 @@ export default function Sidebar() {
             <Link to={isFuncionario ? '/funcionario' : '/professor'} className={linkCls}>
               Formulários
             </Link>
-            <button
-              type="button"
-              onClick={() => handleFakeAction('Formulários Preenchidos')}
-              className={buttonCls}
-            >
+            <Link to="/meus-formularios" className={linkCls}>
               Formulários Preenchidos
-            </button>
+            </Link>
             <button
               type="button"
               onClick={() => handleFakeAction('Informações Pessoais')}

--- a/backend/Formify/formify.client/src/pages/MySubmissionDetail.jsx
+++ b/backend/Formify/formify.client/src/pages/MySubmissionDetail.jsx
@@ -1,0 +1,155 @@
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+
+const formatDate = (iso) => {
+    if (!iso) return '—';
+    try {
+        return new Date(iso).toLocaleString('pt-PT', {
+            day: '2-digit',
+            month: '2-digit',
+            year: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+        });
+    } catch {
+        return iso;
+    }
+};
+
+const formatAnswer = (value) => {
+    if (value === null || value === undefined || value === '') return '—';
+    if (Array.isArray(value)) return value.join(', ');
+    if (typeof value === 'object') return JSON.stringify(value, null, 2);
+    return String(value);
+};
+
+export default function MySubmissionDetail() {
+    const { id } = useParams();
+    const [data, setData] = useState(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState('');
+
+    useEffect(() => {
+        const fetchDetail = async () => {
+            try {
+                setIsLoading(true);
+                setError('');
+
+                const token = localStorage.getItem('token');
+                const response = await fetch(`http://localhost:5208/api/Submissions/me/${id}`, {
+                    headers: token ? { Authorization: `Bearer ${token}` } : {},
+                });
+
+                if (response.status === 401) {
+                    setError('Sessão expirada. Inicia sessão novamente.');
+                    return;
+                }
+                if (response.status === 403) {
+                    setError('Não tens permissão para ver esta submissão.');
+                    return;
+                }
+                if (response.status === 404) {
+                    setError('Submissão não encontrada.');
+                    return;
+                }
+                if (!response.ok) throw new Error('Erro ao obter detalhe');
+
+                const json = await response.json();
+                setData(json);
+            } catch (e) {
+                console.error('Erro ao carregar detalhe:', e);
+                setError('Não foi possível carregar o detalhe da submissão.');
+            } finally {
+                setIsLoading(false);
+            }
+        };
+
+        fetchDetail();
+    }, [id]);
+
+    const fields = data?.form?.fields || data?.form?.Fields || [];
+    const answers = data?.answers || {};
+
+    // Constrói linhas (pergunta, resposta) percorrendo os campos do formulário pela
+    // ordem original. Para garantir cobertura, depois acrescenta respostas extra
+    // cuja chave não corresponda a nenhum campo conhecido.
+    const knownIds = new Set(fields.map((f) => f.id || f.Id));
+    const orderedRows = fields
+        .filter((f) => (f.type || f.Type) !== 'section')
+        .map((f) => {
+            const fid = f.id || f.Id;
+            return {
+                key: fid,
+                label: f.label || f.Label || fid,
+                value: answers[fid],
+            };
+        });
+    const extraRows = Object.entries(answers)
+        .filter(([k]) => !knownIds.has(k))
+        .map(([k, v]) => ({ key: k, label: k, value: v }));
+
+    const rows = [...orderedRows, ...extraRows];
+
+    return (
+        <div className="space-y-6">
+            <Link
+                to="/meus-formularios"
+                className="inline-flex w-fit items-center gap-2 font-semibold text-accent transition-all hover:opacity-80"
+            >
+                ← Voltar
+            </Link>
+
+            {isLoading ? (
+                <div className="text-center py-12 text-text">A carregar detalhe...</div>
+            ) : error ? (
+                <div className="rounded-lg border-2 border-dashed border-red-300 bg-red-50 px-8 py-12 text-center">
+                    <p className="text-xl font-semibold text-red-700">{error}</p>
+                </div>
+            ) : data ? (
+                <>
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                        <div>
+                            <h2 className="text-3xl font-bold text-text-h">
+                                {data.form?.title || data.form?.Title || '(Formulário removido)'}
+                            </h2>
+                            {(data.form?.description || data.form?.Description) && (
+                                <p className="mt-2 text-text">
+                                    {data.form?.description || data.form?.Description}
+                                </p>
+                            )}
+                        </div>
+                        <span className="inline-flex w-fit shrink-0 items-center gap-2 rounded-full bg-accent-bg px-3 py-1 text-sm font-semibold text-accent">
+                            {data.status || 'Submetido'}
+                        </span>
+                    </div>
+
+                    <div className="rounded-lg border border-accent-border bg-white p-4 text-sm text-text">
+                        <span className="font-semibold text-text-h">Submetido a:</span>{' '}
+                        {formatDate(data.submittedAt)}
+                    </div>
+
+                    <div className="rounded-lg border border-accent-border bg-white shadow-sm">
+                        <h3 className="border-b border-accent-border px-6 py-4 text-lg font-bold text-text-h">
+                            Respostas
+                        </h3>
+
+                        {rows.length === 0 ? (
+                            <p className="px-6 py-8 text-center text-text">Esta submissão não tem respostas registadas.</p>
+                        ) : (
+                            <dl className="divide-y divide-gray-100">
+                                {rows.map((row) => (
+                                    <div key={row.key} className="grid gap-1 px-6 py-4 sm:grid-cols-3 sm:gap-4">
+                                        <dt className="text-sm font-semibold text-text-h sm:col-span-1">{row.label}</dt>
+                                        <dd className="whitespace-pre-wrap text-sm text-text sm:col-span-2">
+                                            {formatAnswer(row.value)}
+                                        </dd>
+                                    </div>
+                                ))}
+                            </dl>
+                        )}
+                    </div>
+                </>
+            ) : null}
+        </div>
+    );
+}

--- a/backend/Formify/formify.client/src/pages/MySubmissions.jsx
+++ b/backend/Formify/formify.client/src/pages/MySubmissions.jsx
@@ -1,0 +1,194 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+
+const API_URL = 'http://localhost:5208/api/Submissions/me';
+
+const normalizeText = (value) =>
+    (value || '').toString().toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '');
+
+const formatDate = (iso) => {
+    if (!iso) return '—';
+    try {
+        return new Date(iso).toLocaleString('pt-PT', {
+            day: '2-digit',
+            month: '2-digit',
+            year: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+        });
+    } catch {
+        return iso;
+    }
+};
+
+export default function MySubmissions() {
+    const [submissions, setSubmissions] = useState([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState('');
+
+    const [searchTerm, setSearchTerm] = useState('');
+    const [sortDate, setSortDate] = useState('newest');
+
+    const [currentPage, setCurrentPage] = useState(1);
+    const itemsPerPage = 12;
+
+    useEffect(() => {
+        const fetchSubmissions = async () => {
+            try {
+                setIsLoading(true);
+                setError('');
+
+                const token = localStorage.getItem('token');
+                const response = await fetch(API_URL, {
+                    headers: token ? { Authorization: `Bearer ${token}` } : {},
+                });
+
+                if (response.status === 401) {
+                    setError('Sessão expirada. Inicia sessão novamente.');
+                    setSubmissions([]);
+                    return;
+                }
+
+                if (!response.ok) throw new Error('Erro ao obter submissões');
+
+                const data = await response.json();
+                setSubmissions(Array.isArray(data) ? data : []);
+            } catch (e) {
+                console.error('Erro ao carregar submissões:', e);
+                setError('Não foi possível carregar as tuas submissões.');
+            } finally {
+                setIsLoading(false);
+            }
+        };
+
+        fetchSubmissions();
+    }, []);
+
+    const filteredAndSorted = useMemo(() => {
+        const term = normalizeText(searchTerm.trim());
+
+        const filtered = submissions.filter((s) => {
+            if (!term) return true;
+            const title = normalizeText(s.formTitle);
+            const description = normalizeText(s.formDescription);
+            const tokens = term.split(/\s+/).filter(Boolean);
+            const words = `${title} ${description}`.split(/[^a-z0-9]+/).filter(Boolean);
+            return tokens.every((tok) => words.some((w) => w.startsWith(tok)));
+        });
+
+        return [...filtered].sort((a, b) => {
+            const dateA = new Date(a.submittedAt || 0).getTime();
+            const dateB = new Date(b.submittedAt || 0).getTime();
+            return sortDate === 'oldest' ? dateA - dateB : dateB - dateA;
+        });
+    }, [submissions, searchTerm, sortDate]);
+
+    const totalPages = Math.max(1, Math.ceil(filteredAndSorted.length / itemsPerPage));
+    const paginated = filteredAndSorted.slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage);
+
+    useEffect(() => {
+        setCurrentPage(1);
+    }, [searchTerm, sortDate]);
+
+    return (
+        <div className="min-h-[calc(100vh-140px)] space-y-8 flex flex-col">
+            <div className="flex flex-col gap-2">
+                <h2 className="text-3xl font-bold text-text-h">Os meus formulários</h2>
+                <p className="text-lg text-text">Histórico de formulários que já preencheste</p>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2 my-2">
+                <div className="flex flex-col gap-2">
+                    <label className="font-medium text-text-h">Pesquisar</label>
+                    <input
+                        type="text"
+                        value={searchTerm}
+                        onChange={(e) => setSearchTerm(e.target.value)}
+                        placeholder="Nome do formulário..."
+                        className="rounded-md border border-accent-border bg-white p-2 focus:border-accent focus:outline-none"
+                    />
+                </div>
+                <div className="flex flex-col gap-2">
+                    <label className="font-medium text-text-h">Ordenar por</label>
+                    <select
+                        value={sortDate}
+                        onChange={(e) => setSortDate(e.target.value)}
+                        className="rounded-md border border-accent-border bg-white p-2 focus:border-accent focus:outline-none"
+                    >
+                        <option value="newest">Mais recentes</option>
+                        <option value="oldest">Mais antigos</option>
+                    </select>
+                </div>
+            </div>
+
+            <div className="rounded-lg flex-1 flex flex-col">
+                {isLoading ? (
+                    <div className="text-center py-12 text-text">A carregar submissões...</div>
+                ) : error ? (
+                    <div className="rounded-lg border-2 border-dashed border-red-300 bg-red-50 px-8 py-12 text-center">
+                        <p className="text-xl font-semibold text-red-700">{error}</p>
+                    </div>
+                ) : filteredAndSorted.length === 0 ? (
+                    <div className="rounded-lg border-2 border-dashed border-accent-border bg-accent-bg px-8 py-12 text-center">
+                        <p className="text-xl font-semibold text-text-h">Ainda não preencheste formulários</p>
+                        <p className="mt-2 text-text">As tuas submissões vão aparecer aqui assim que responderes ao primeiro formulário.</p>
+                    </div>
+                ) : (
+                    <>
+                        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                            {paginated.map((s) => (
+                                <Link
+                                    key={s.id}
+                                    to={`/meus-formularios/${s.id}`}
+                                    className="group flex flex-col h-full rounded-lg border border-accent-border p-6 shadow-sm hover:shadow-md hover:border-accent transition-all bg-white"
+                                >
+                                    <div className="flex items-start justify-between gap-3 mb-3">
+                                        <h3 className="font-bold text-lg text-text-h group-hover:text-accent transition-colors">
+                                            {s.formTitle}
+                                        </h3>
+                                        <span className="shrink-0 rounded-full bg-accent-bg px-3 py-1 text-xs font-semibold text-accent">
+                                            {s.status || 'Submetido'}
+                                        </span>
+                                    </div>
+
+                                    {s.formDescription && (
+                                        <p className="text-sm text-text line-clamp-3 flex-grow">{s.formDescription}</p>
+                                    )}
+
+                                    <div className="mt-4 pt-4 border-t border-gray-100 mt-auto flex items-center justify-between">
+                                        <span className="text-xs text-text">{formatDate(s.submittedAt)}</span>
+                                        <span className="text-sm font-semibold text-accent group-hover:text-emerald-700">
+                                            Ver detalhes →
+                                        </span>
+                                    </div>
+                                </Link>
+                            ))}
+                        </div>
+
+                        {totalPages > 1 && (
+                            <div className="mt-auto pt-6 flex items-center justify-between">
+                                <button
+                                    type="button"
+                                    onClick={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
+                                    disabled={currentPage === 1}
+                                    className="rounded-md border border-accent-border px-4 py-2 disabled:cursor-not-allowed disabled:opacity-50"
+                                >
+                                    Anterior
+                                </button>
+                                <span className="text-sm text-text">Página {currentPage} de {totalPages}</span>
+                                <button
+                                    type="button"
+                                    onClick={() => setCurrentPage((prev) => Math.min(totalPages, prev + 1))}
+                                    disabled={currentPage === totalPages}
+                                    className="rounded-md border border-accent-border px-4 py-2 disabled:cursor-not-allowed disabled:opacity-50"
+                                >
+                                    Próxima
+                                </button>
+                            </div>
+                        )}
+                    </>
+                )}
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Sumário

Implementa a sub-issue #135 — utilizador autenticado consulta histórico das suas submissões e abre o detalhe das respostas.

**Backend**
- Novo `SubmissionsController` (`api/Submissions`) com `[Authorize]`.
- `GET /me` — devolve as submissões do utilizador autenticado (filtro por `UserId` do JWT), enriquecidas com `formTitle`/`formDescription`.
- `GET /me/{id}` — devolve a submissão + o `form` completo (para mostrar perguntas/labels). Devolve 403 se a submissão não pertencer ao utilizador.

**Frontend**
- `MySubmissions.jsx` — lista responsiva com pesquisa, ordenação por data e paginação. Badge de estado "Submetido".
- `MySubmissionDetail.jsx` — detalhe pergunta → resposta pela ordem original dos campos, respostas extra mostradas no fim. Trata arrays/objetos.
- Rotas `/meus-formularios` e `/meus-formularios/:id` em `App.jsx`, protegidas para `professor` e `funcionario`.
- Sidebar de utilizador: link "Formulários Preenchidos" passou de placeholder para `Link` real; deteção de `isUserView` agora considera a role do localStorage e `/meus-formularios`.

## Critérios de aceitação

- [x] Utilizador vê os seus formulários preenchidos.
- [x] Dados carregados corretamente do backend.
- [x] Interface responsiva.
- [x] Histórico ordenado por data (default desc, alterável).
- [x] Detalhes das respostas apresentados corretamente.
- [x] Apenas submissões do próprio utilizador acessíveis (filtro server-side pelo `UserId` do JWT + 403 no detalhe alheio).
- [x] Dados protegidos por autenticação (`[Authorize]` no controller, `ProtectedRoute` no cliente).

## Test plan

- [ ] Login como `professor` ou `funcionario` com submissões existentes (ex: UserId 5 ou 14 no `SubmissionsList.json`).
- [ ] Sidebar → "Formulários Preenchidos" → lista renderiza com cards.
- [ ] Pesquisa por título funciona; alternar ordenação altera a ordem.
- [ ] Clicar num card abre detalhe com perguntas + respostas legíveis.
- [ ] Submeter um novo formulário e voltar — aparece no topo da lista.
- [ ] Trocar token/utilizador: não vê submissões alheias; chamada direta a `/api/Submissions/me/{id}` de outro user devolve 403.
- [ ] Sem token: redireciona para `/login`.
