### PR TITLE
fix: invalidar sessao em restart de dev e polish login/register/admin…

### DIFF
--- a/backend/Formify/Formify.Server/Controllers/AuthController.cs
+++ b/backend/Formify/Formify.Server/Controllers/AuthController.cs
@@ -1,5 +1,6 @@
 using Formify.Server.Models;
 using Formify.Server.Services;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Text.Json;
 using System.IdentityModel.Tokens.Jwt;
@@ -92,6 +93,36 @@ namespace Formify.Server.Controllers
             var jwt = tokenHandler.WriteToken(token);
 
             return Ok(new { token = jwt, role = user.Role, username = user.Username });
+        }
+
+        // GET /api/auth/me
+        // Valida o token JWT do utilizador autenticado e devolve os dados atuais.
+        // O frontend usa esta chamada no arranque para detetar tokens revogados,
+        // utilizadores entretanto removidos ou estados inconsistentes (devolve 401).
+        [HttpGet("me")]
+        [Authorize]
+        public async Task<IActionResult> GetMe()
+        {
+            var idClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (string.IsNullOrEmpty(idClaim) || !int.TryParse(idClaim, out var userId))
+            {
+                return Unauthorized(new { error = "Token inválido." });
+            }
+
+            var users = await _usersService.GetAllAsync();
+            var user = users.FirstOrDefault(u => u.Id == userId);
+            if (user == null)
+            {
+                return Unauthorized(new { error = "Utilizador já não existe." });
+            }
+
+            return Ok(new
+            {
+                userId = user.Id,
+                username = user.Username,
+                name = user.Name,
+                role = user.Role
+            });
         }
     }
 

--- a/backend/Formify/Formify.Server/Program.cs
+++ b/backend/Formify/Formify.Server/Program.cs
@@ -7,6 +7,17 @@ using System.Text;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Em ambiente de desenvolvimento, gerar uma JWT key aleatória a cada arranque.
+// Isto invalida todos os tokens emitidos antes do restart, forçando o utilizador
+// a re-autenticar-se (comportamento desejado em dev para evitar sessões "fantasma"
+// entre runs). Em produção lê a chave de configuração, como antes.
+if (builder.Environment.IsDevelopment())
+{
+    var randomKey = Convert.ToBase64String(
+        System.Security.Cryptography.RandomNumberGenerator.GetBytes(32));
+    builder.Configuration["Jwt:Key"] = randomKey;
+}
+
 // Add services to the container.
 builder.Services.AddControllers()
     .ConfigureApiBehaviorOptions(options =>

--- a/backend/Formify/formify.client/src/App.jsx
+++ b/backend/Formify/formify.client/src/App.jsx
@@ -9,6 +9,7 @@ import ViewForm from './pages/ViewForm';
 import ProfessorDashboard from './pages/Professor/ProfessorDashboard';
 import FuncionarioDashboard from './pages/Funcionario/FuncionarioDashboard';
 import ProtectedRoute from './components/Auth/ProtectedRoute';
+import SessionGuard from './components/Auth/SessionGuard';
 import RespondForm from './pages/RespondForm';
 import MySubmissions from './pages/MySubmissions';
 import MySubmissionDetail from './pages/MySubmissionDetail';
@@ -16,6 +17,7 @@ import MySubmissionDetail from './pages/MySubmissionDetail';
 export default function App() {
     return (
         <Router>
+            <SessionGuard />
             <Layout>
                 <Routes>
                     <Route path="/" element={<Landing />} />

--- a/backend/Formify/formify.client/src/components/Auth/SessionGuard.jsx
+++ b/backend/Formify/formify.client/src/components/Auth/SessionGuard.jsx
@@ -1,0 +1,53 @@
+import { useEffect } from 'react';
+
+const AUTH_ME_URL = 'http://localhost:5208/api/auth/me';
+
+/**
+ * SessionGuard
+ *
+ * Valida o token JWT contra o backend uma vez no arranque da aplicação.
+ * - 200: sincroniza role/username no localStorage com a resposta do servidor.
+ * - 401: limpa a sessão (token inválido, expirado ou utilizador removido).
+ * - Erro de rede: NÃO mexe na sessão — backend pode estar offline e queremos
+ *   continuar a tratar o utilizador como logado para não estragar a UX.
+ */
+export default function SessionGuard() {
+    useEffect(() => {
+        const token = localStorage.getItem('token');
+        if (!token) return;
+
+        const controller = new AbortController();
+
+        const validate = async () => {
+            try {
+                const response = await fetch(AUTH_ME_URL, {
+                    headers: { Authorization: `Bearer ${token}` },
+                    signal: controller.signal,
+                });
+
+                if (response.status === 401) {
+                    localStorage.removeItem('token');
+                    localStorage.removeItem('role');
+                    localStorage.removeItem('username');
+                    window.dispatchEvent(new Event('app:logout'));
+                    return;
+                }
+
+                if (!response.ok) return;
+
+                const data = await response.json();
+                if (data?.role) localStorage.setItem('role', data.role);
+                if (data?.username) localStorage.setItem('username', data.username);
+            } catch (error) {
+                if (error.name !== 'AbortError') {
+                    console.warn('Não foi possível validar a sessão (backend offline?).', error);
+                }
+            }
+        };
+
+        validate();
+        return () => controller.abort();
+    }, []);
+
+    return null;
+}

--- a/backend/Formify/formify.client/src/pages/AdminDashboard.jsx
+++ b/backend/Formify/formify.client/src/pages/AdminDashboard.jsx
@@ -259,15 +259,13 @@ export default function AdminDashboard({ isDraft = false }) {
             {/* Blocos de estatísticas (A plataforma em números) */}
             <div className="grid gap-4 sm:grid-cols-3">
                 <div className="rounded-lg border border-accent-border p-6 bg-white">
-                    <h3 className="text-sm font-medium text-text-h">A plataforma em números</h3>
-                    <p className="text-xs text-text mt-1">Dados em tempo real do sistema</p>
+                    <h3 className="text-sm font-medium text-text-h">Formulários no total</h3>
+                    <p className="text-xs text-text mt-1">A crescer com a atividade do IPT</p>
 
                     <div className="mt-4">
                         <div className="text-3xl font-bold text-green-700">
                             {isStatsLoading ? '—' : stats.totalForms}
                         </div>
-                        <div className="text-sm text-text mt-1">Formulários no total</div>
-                        <div className="text-xs text-text mt-2">A crescer com a atividade do IPT</div>
                     </div>
                 </div>
 

--- a/backend/Formify/formify.client/src/pages/Login.jsx
+++ b/backend/Formify/formify.client/src/pages/Login.jsx
@@ -2,16 +2,20 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 
 function FloatingField({ id, label, type = 'text', value, onChange, autoComplete }) {
+    const isPassword = type === 'password';
+    const [show, setShow] = useState(false);
+    const actualType = isPassword && show ? 'text' : type;
+
     return (
         <div className="relative">
             <input
                 id={id}
-                type={type}
+                type={actualType}
                 value={value}
                 onChange={onChange}
                 autoComplete={autoComplete}
                 placeholder=" "
-                className="peer w-full rounded border border-border px-3 pb-2 pt-5 outline-none transition-colors focus:border-accent"
+                className={`peer w-full rounded border border-border ${isPassword ? 'pr-10' : ''} px-3 pb-2 pt-5 outline-none transition-colors focus:border-accent`}
             />
             <label
                 htmlFor={id}
@@ -19,6 +23,26 @@ function FloatingField({ id, label, type = 'text', value, onChange, autoComplete
             >
                 {label}
             </label>
+            {isPassword && (
+                <button
+                    type="button"
+                    onClick={() => setShow(s => !s)}
+                    aria-label={show ? 'Ocultar password' : 'Mostrar password'}
+                    aria-pressed={show}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-text transition-colors hover:text-accent focus:outline-none focus:ring-2 focus:ring-accent"
+                >
+                    {show ? (
+                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                            <path d="M3 3l18 18M10.6 10.6a3 3 0 0 0 4.2 4.2M9.9 4.7A10.9 10.9 0 0 1 12 4.5c5 0 9 4 10 7.5a12.4 12.4 0 0 1-3.6 4.7M6.5 6.5C4.3 8 2.7 10 2 12c1 3.5 5 7.5 10 7.5 1.6 0 3-.3 4.3-.9" />
+                        </svg>
+                    ) : (
+                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                            <path d="M2 12s3.6-7.5 10-7.5S22 12 22 12s-3.6 7.5-10 7.5S2 12 2 12z" />
+                            <circle cx="12" cy="12" r="3" />
+                        </svg>
+                    )}
+                </button>
+            )}
         </div>
     );
 }
@@ -67,8 +91,15 @@ export default function Login() {
     };
 
     return (
-        <div className="flex min-h-[calc(100vh-140px)] items-center justify-center px-4 py-12 sm:px-6 lg:px-8">
+        <div className="flex min-h-[calc(100vh-140px)] items-center justify-center bg-gradient-to-br from-emerald-50 via-white to-emerald-50 px-4 py-12 sm:px-6 lg:px-8">
             <div className="w-full max-w-md space-y-6 rounded-lg border border-border bg-white p-8 shadow-custom">
+                <Link
+                    to="/"
+                    className="inline-flex w-fit items-center gap-2 text-sm font-semibold text-accent transition-opacity hover:opacity-80"
+                >
+                    ← Voltar à página inicial
+                </Link>
+
                 <div className="text-center">
                     <h1 className="text-3xl font-bold text-accent">Iniciar sessão</h1>
                     <p className="mt-2 text-sm text-text">Introduza as suas credenciais.</p>

--- a/backend/Formify/formify.client/src/pages/Register.jsx
+++ b/backend/Formify/formify.client/src/pages/Register.jsx
@@ -2,16 +2,20 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 
 function FloatingField({ id, label, type = 'text', value, onChange, autoComplete }) {
+    const isPassword = type === 'password';
+    const [show, setShow] = useState(false);
+    const actualType = isPassword && show ? 'text' : type;
+
     return (
         <div className="relative">
             <input
                 id={id}
-                type={type}
+                type={actualType}
                 value={value}
                 onChange={onChange}
                 autoComplete={autoComplete}
                 placeholder=" "
-                className="peer w-full rounded border border-border px-3 pb-2 pt-5 outline-none transition-colors focus:border-accent"
+                className={`peer w-full rounded border border-border ${isPassword ? 'pr-10' : ''} px-3 pb-2 pt-5 outline-none transition-colors focus:border-accent`}
             />
             <label
                 htmlFor={id}
@@ -19,6 +23,26 @@ function FloatingField({ id, label, type = 'text', value, onChange, autoComplete
             >
                 {label}
             </label>
+            {isPassword && (
+                <button
+                    type="button"
+                    onClick={() => setShow(s => !s)}
+                    aria-label={show ? 'Ocultar password' : 'Mostrar password'}
+                    aria-pressed={show}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-text transition-colors hover:text-accent focus:outline-none focus:ring-2 focus:ring-accent"
+                >
+                    {show ? (
+                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                            <path d="M3 3l18 18M10.6 10.6a3 3 0 0 0 4.2 4.2M9.9 4.7A10.9 10.9 0 0 1 12 4.5c5 0 9 4 10 7.5a12.4 12.4 0 0 1-3.6 4.7M6.5 6.5C4.3 8 2.7 10 2 12c1 3.5 5 7.5 10 7.5 1.6 0 3-.3 4.3-.9" />
+                        </svg>
+                    ) : (
+                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                            <path d="M2 12s3.6-7.5 10-7.5S22 12 22 12s-3.6 7.5-10 7.5S2 12 2 12z" />
+                            <circle cx="12" cy="12" r="3" />
+                        </svg>
+                    )}
+                </button>
+            )}
         </div>
     );
 }
@@ -89,8 +113,15 @@ export default function Register() {
     };
 
     return (
-        <div className="flex min-h-[calc(100vh-140px)] items-center justify-center px-4 py-12 sm:px-6 lg:px-8">
+        <div className="flex min-h-[calc(100vh-140px)] items-center justify-center bg-gradient-to-br from-emerald-50 via-white to-emerald-50 px-4 py-12 sm:px-6 lg:px-8">
             <div className="w-full max-w-md space-y-6 rounded-lg border border-border bg-white p-8 shadow-custom">
+                <Link
+                    to="/"
+                    className="inline-flex w-fit items-center gap-2 text-sm font-semibold text-accent transition-opacity hover:opacity-80"
+                >
+                    ← Voltar à página inicial
+                </Link>
+
                 <div className="text-center">
                     <h1 className="text-3xl font-bold text-accent">Criar conta</h1>
                     <p className="mt-2 text-sm text-text">Preencha os dados para criar a sua conta.</p>


### PR DESCRIPTION
## Sumário

Resolve o problema de sessão persistente entre restarts do backend em dev e inclui correções de UX no login, registo e dashboard de admin.

### Sessão / Auth
- **Backend:** em `IsDevelopment()`, `Program.cs` gera uma JWT key aleatória a cada arranque — tokens emitidos em runs anteriores ficam inválidos.
- **Backend:** novo `GET /api/auth/me` (`[Authorize]`) — valida o token e devolve `{userId, username, name, role}`; 401 se o user foi removido ou o token é inválido.
- **Frontend:** novo `<SessionGuard />` montado em `App.jsx`. No arranque, valida o token contra `/api/auth/me`; se 401, limpa `localStorage` e dispara `app:logout`. Se for erro de rede (backend offline), não mexe na sessão.
- **Produção:** sem alterações — a JWT key continua a vir de `appsettings`/env.

### Login / Register polish
- Toggle de visibilidade da password com ícone de olho (SVG inline) — `aria-label`/`aria-pressed`, password oculta por default.
- Link `← Voltar à página inicial` no topo de ambos os cards.
- Gradiente verde-claro (`emerald-50`) no fundo de ambos os ecrãs.

### Admin dashboard
- Corrigido o card "Formulários no total" que tinha estrutura diferente dos outros 2 (cabeçalho extra + label/descrição abaixo do número) e ficava desalinhado.

## Test plan

- [ ] Login. Parar backend. Reiniciar. F5 → vai para `/` (deslogado). Login outra vez funciona.
- [ ] Login. Apagar utilizador de `users.json`. F5 → deslogado (via `/me` 401).
- [ ] Parar backend com user logado → app continua funcional, não desloga (erro de rede).
- [ ] Login e Register: clicar no olho mostra/esconde password; toggles independentes no Register (Password vs Confirmar Password).
- [ ] Login e Register: link "Voltar à página inicial" navega para `/`.
- [ ] AdminDashboard: 3 cards de stats alinhados, mesmo tamanho/estrutura.

## Notas

- Em produção, a chave continua estável — `IsDevelopment()` é falso e o `Program.cs` não substitui a config.
- O `SessionGuard` faz logout silencioso ao detetar 401: o utilizador continua na página atual até navegar ou refrescar. Para a #109 (cenário "reiniciei o backend") isto é suficiente.
