### PR TITLE
fix: harmonizar pagina MyInfo com a paleta IPT e remover duplicacao

### DIFF
--- a/backend/Formify/formify.client/src/components/Layout/Sidebar.jsx
+++ b/backend/Formify/formify.client/src/components/Layout/Sidebar.jsx
@@ -24,11 +24,6 @@ export default function Sidebar() {
   const buttonCls =
     'block w-full text-left rounded-lg px-4 py-2 text-sm font-medium text-text transition-colors hover:bg-accent-bg hover:text-accent';
 
-  // Placeholder enquanto não existe sistema de autenticação real.
-  const handleFakeAction = (label) => {
-    alert(`${label}: funcionalidade em desenvolvimento.`);
-  };
-
   const handleLogout = () => {
     // Limpar dados de autenticação no client e redirecionar para a landing
     localStorage.removeItem('token');

--- a/backend/Formify/formify.client/src/pages/MyInfo.jsx
+++ b/backend/Formify/formify.client/src/pages/MyInfo.jsx
@@ -1,148 +1,118 @@
-﻿import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+
+const ROLE_LABELS = {
+    admin: 'Administrador',
+    professor: 'Professor',
+    funcionario: 'Funcionário',
+};
+
+const formatRole = (role) =>
+    ROLE_LABELS[(role || '').toLowerCase()] || role || '—';
+
+const getInitials = (name, username) => {
+    const source = (name || username || '').trim();
+    if (!source) return '?';
+    const parts = source.split(/\s+/).filter(Boolean);
+    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+};
 
 export default function MyInfo() {
-    const navigate = useNavigate();
-
-    const [showPersonalInfo, setShowPersonalInfo] = useState(false);
-
-    const [user, setUser] = useState({
-        username: '',
-        role: '',
-        name: ''
-    });
+    const [user, setUser] = useState({ username: '', role: '', name: '' });
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState('');
 
     useEffect(() => {
+        const controller = new AbortController();
+
         const fetchUser = async () => {
             try {
+                setIsLoading(true);
+                setError('');
+
                 const username = localStorage.getItem('username');
                 const token = localStorage.getItem('token');
-
-                if (!username || !token) return;
-
-                const response = await fetch(
-                    `/api/Auth/user/${username}`,
-                    {
-                        headers: {
-                            Authorization: `Bearer ${token}`
-                        }
-                    }
-                );
-
-                if (!response.ok) {
-                    throw new Error('Erro ao buscar utilizador');
+                if (!username || !token) {
+                    setError('Sessão não encontrada.');
+                    return;
                 }
 
-                const data = await response.json();
-
-                setUser({
-                    username: data.username,
-                    role: data.role,
-                    name: data.name
+                const response = await fetch(`/api/Auth/user/${username}`, {
+                    headers: { Authorization: `Bearer ${token}` },
+                    signal: controller.signal,
                 });
 
-            } catch (error) {
-                console.error(error);
+                if (response.status === 401) {
+                    setError('Sessão expirada. Inicia sessão novamente.');
+                    return;
+                }
+                if (!response.ok) throw new Error('Erro ao obter utilizador');
+
+                const data = await response.json();
+                setUser({ username: data.username, role: data.role, name: data.name });
+            } catch (e) {
+                if (e.name === 'AbortError') return;
+                console.error('Erro ao carregar perfil:', e);
+                setError('Não foi possível carregar as tuas informações.');
+            } finally {
+                setIsLoading(false);
             }
         };
 
         fetchUser();
+        return () => controller.abort();
     }, []);
 
-    const handleLogout = () => {
-        localStorage.clear();
-        navigate('/');
-    };
-
     return (
-        <div className="space-y-6">
-
-            <div className="max-w-xl mx-auto py-4">
-                <h2 className="text-2xl font-bold">
-                    As minhas informações
-                </h2>
-
-                <div className="bg-white rounded p-4 shadow mt-3">
-
-                    <p><strong>Nome:</strong> {user.name}</p>
-                    <p><strong>Username:</strong> {user.username}</p>
-                    <p><strong>Função:</strong> {user.role}</p>
-
-                    <div className="mt-3 flex gap-2">
-
-                        <button
-                            onClick={() => setShowPersonalInfo(!showPersonalInfo)}
-                            className="px-3 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
-                        >
-                            {showPersonalInfo ? 'Ocultar' : 'Ver'} Informações Pessoais
-                        </button>
-
-                        <button
-                            onClick={handleLogout}
-                            className="px-3 py-2 bg-red-500 text-white rounded hover:bg-red-600"
-                        >
-                            Logout
-                        </button>
-
-                    </div>
-                </div>
-
-                {showPersonalInfo && (
-                    <div className="bg-white rounded p-4 shadow mt-4 border-l-4 border-blue-500">
-
-                        <h3 className="text-xl font-semibold mb-4">
-                            Informações de Registo
-                        </h3>
-
-                        <div className="space-y-3">
-
-                            <div className="grid grid-cols-2 gap-3">
-                                <div>
-                                    <label className="text-sm font-semibold text-gray-600">
-                                        Nome
-                                    </label>
-                                    <div className="mt-1 p-2 bg-gray-50 rounded border">
-                                        {user.name}
-                                    </div>
-                                </div>
-
-                                <div>
-                                    <label className="text-sm font-semibold text-gray-600">
-                                        Username
-                                    </label>
-                                    <div className="mt-1 p-2 bg-gray-50 rounded border">
-                                        {user.username}
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div className="grid grid-cols-2 gap-3">
-                                <div>
-                                    <label className="text-sm font-semibold text-gray-600">
-                                        Função
-                                    </label>
-                                    <div className="mt-1 p-2 bg-gray-50 rounded border">
-                                        {user.role}
-                                    </div>
-                                </div>
-                            </div>
-
-                        </div>
-
-                        <div className="mt-4 pt-4 border-t">
-
-                            <button
-                                className="px-3 py-2 bg-gray-400 text-white rounded hover:bg-gray-500"
-                                onClick={() => setShowPersonalInfo(false)}
-                            >
-                                Fechar
-                            </button>
-
-                        </div>
-                    </div>
-                )}
+        <div className="min-h-[calc(100vh-140px)] space-y-8 flex flex-col">
+            <div className="flex flex-col gap-2">
+                <h2 className="text-3xl font-bold text-text-h">Informações pessoais</h2>
+                <p className="text-lg text-text">Os dados da tua conta no Formify</p>
             </div>
 
+            {isLoading ? (
+                <div className="text-center py-12 text-text">A carregar perfil...</div>
+            ) : error ? (
+                <div className="rounded-lg border-2 border-dashed border-red-300 bg-red-50 px-8 py-12 text-center">
+                    <p className="text-xl font-semibold text-red-700">{error}</p>
+                </div>
+            ) : (
+                <div className="mx-auto w-full max-w-2xl">
+                    <div className="rounded-lg border border-accent-border bg-white shadow-sm">
+                        <div className="flex items-center gap-4 border-b border-accent-border p-6">
+                            <div
+                                className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-accent text-2xl font-bold text-white"
+                                aria-hidden="true"
+                            >
+                                {getInitials(user.name, user.username)}
+                            </div>
+                            <div className="min-w-0">
+                                <h3 className="truncate text-xl font-bold text-text-h">
+                                    {user.name || '—'}
+                                </h3>
+                                <span className="mt-1 inline-flex w-fit items-center rounded-full bg-accent-bg px-3 py-1 text-xs font-semibold text-accent">
+                                    {formatRole(user.role)}
+                                </span>
+                            </div>
+                        </div>
+
+                        <dl className="divide-y divide-gray-100">
+                            <Row label="Nome" value={user.name} />
+                            <Row label="Username" value={user.username} />
+                            <Row label="Função" value={formatRole(user.role)} />
+                        </dl>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}
+
+function Row({ label, value }) {
+    return (
+        <div className="grid gap-1 px-6 py-4 sm:grid-cols-3 sm:gap-4">
+            <dt className="text-sm font-semibold text-text-h sm:col-span-1">{label}</dt>
+            <dd className="text-sm text-text sm:col-span-2">{value || '—'}</dd>
         </div>
     );
 }


### PR DESCRIPTION
## Sumário

A página `/myinfo` estava visualmente desalinhada com o resto do site (cores `blue-500`/`red-500`/`gray-50` em vez da paleta `accent`/`accent-bg`/`text`) e tinha informação duplicada (mostrava Nome/Username/Função em cima e o toggle "Ver Informações Pessoais" abria uma segunda secção com os mesmos campos).

### MyInfo.jsx
- Layout coerente com o resto do site: `min-h-[calc(100vh-140px)]`, header `text-3xl font-bold text-text-h` + subtítulo, container `max-w-2xl` centrado.
- Paleta IPT: `accent` / `accent-bg` / `accent-border` / `text` / `text-h`.
- Card de perfil com avatar circular verde (iniciais), nome em destaque e badge da role com labels legíveis (`Professor` / `Funcionário` / `Administrador`).
- Lista `<dl>` Nome / Username / Função no estilo do detalhe de submissões.
- Estados de loading e erro coerentes; trata 401 como "sessão expirada".
- Removidas a duplicação (toggle "Ver Informações Pessoais") e o botão Logout (já existe na sidebar).

### Sidebar.jsx
- Removido o `handleFakeAction` morto que estava a fazer falhar o `npm run lint` (placeholder que ficou após substituir o botão "Informações Pessoais" pelo `Link to="/myinfo"`).

## Test plan

- [ ] Login como professor ou funcionário → sidebar → "Informações Pessoais".
- [ ] Card mostra avatar com iniciais, nome, badge da role e a lista Nome/Username/Função.
- [ ] `npm run lint` e `npm run build` passam sem erros.
- [ ] Logout pela sidebar continua a funcionar (botão removido da MyInfo).
