### PR TITLE
feat: unificar estado dos formulários e adicionar duplicar/arquivar/versão (#181)

### DIFF
--- a/backend/Formify/Formify.Server/Controllers/FormsController.cs
+++ b/backend/Formify/Formify.Server/Controllers/FormsController.cs
@@ -18,34 +18,34 @@ namespace Formify.Server.Controllers
             _jsonHandler = jsonHandler;
         }
 
+        // Mapeia o flag legacy `StatusDraft` do DTO (bool) para o novo enum.
+        // Mantemos o DTO inalterado por compatibilidade com o frontend.
+        private static FormStatus StatusFromRequest(bool isDraft) =>
+            isDraft ? FormStatus.Draft : FormStatus.Published;
+
         [HttpPost]
         public async Task<IActionResult> Create([FromBody] CreateFormRequest request)
         {
-            // Garante que o formulário tem nome.
             if (string.IsNullOrWhiteSpace(request.Title))
             {
                 ModelState.AddModelError(nameof(request.Title), "O nome do formulário é obrigatório.");
             }
 
-            // Garante que foi selecionado pelo menos um público-alvo.
             if (request.Audience == null || !request.Audience.Any())
             {
                 ModelState.AddModelError(nameof(request.Audience), "É obrigatório selecionar pelo menos um público-alvo.");
             }
 
-            // Garante que o formulário tem pelo menos um campo real.
             if (request.Fields == null || !request.Fields.Any(f => f.Type != "section"))
             {
                 ModelState.AddModelError(nameof(request.Fields), "O formulário deve conter pelo menos um campo.");
             }
 
-            // If any of our manual business checks failed, trigger the validation problem format
             if (!ModelState.IsValid)
             {
                 return ValidationProblem(ModelState);
             }
 
-            // Carrega os formulários existentes para gerar o próximo ID e acrescentar o novo formulário.
             var allForms = await _jsonHandler.GetAllFormsAsync();
 
             var form = new Form
@@ -54,7 +54,7 @@ namespace Formify.Server.Controllers
                 Title = request.Title.Trim(),
                 Description = request.Description?.Trim(),
                 Audience = request.Audience,
-                StatusDrafted = request.StatusDraft,
+                Status = StatusFromRequest(request.StatusDraft),
                 CreatedAt = DateTime.Now,
                 UpdatedAt = DateTime.Now,
                 Fields = request.Fields
@@ -66,68 +66,79 @@ namespace Formify.Server.Controllers
             return CreatedAtAction(nameof(GetById), new { id = form.Id }, form);
         }
 
+        // GET /api/forms[?status=draft|published|archived]
+        // Sem `status`, devolve tudo o que não está arquivado.
+        // Mantém-se compat com `?onlyArchived=true` e `?includeArchived=true`.
         [HttpGet]
-        public async Task<IActionResult> GetAllForms()
+        public async Task<IActionResult> GetAllForms(
+            [FromQuery] string? status = null,
+            [FromQuery] bool includeArchived = false,
+            [FromQuery] bool onlyArchived = false)
         {
-            // Carrega a lista completa de formulários guardados no ficheiro JSON.
             var allForms = await _jsonHandler.GetAllFormsAsync();
-
             if (allForms == null)
             {
                 return NotFound(new { message = "No forms were found" });
             }
 
-            return Ok(allForms);
+            IEnumerable<Form> result = allForms;
+
+            if (!string.IsNullOrWhiteSpace(status))
+            {
+                if (Enum.TryParse<FormStatus>(status, ignoreCase: true, out var s))
+                    result = result.Where(f => f.Status == s);
+                else
+                    return BadRequest(new { message = $"Status inválido: '{status}'. Valores: draft, published, archived." });
+            }
+            else if (onlyArchived)
+            {
+                result = result.Where(f => f.Status == FormStatus.Archived);
+            }
+            else if (!includeArchived)
+            {
+                result = result.Where(f => f.Status != FormStatus.Archived);
+            }
+
+            return Ok(result.ToList());
         }
 
         [HttpGet("published")]
         public async Task<IActionResult> GetPublishedForms()
         {
-            // 1. Vai buscar todos os formulários ao ficheiro JSON
             var allForms = await _jsonHandler.GetAllFormsAsync();
-
             if (allForms == null)
             {
                 return Ok(new List<Form>());
             }
 
-            // 2. Filtra apenas os que estão publicados
-            var publishedForms = allForms.Where(f => !f.StatusDrafted).ToList();
-
-            // 3. Devolve a lista filtrada
+            var publishedForms = allForms.Where(f => f.Status == FormStatus.Published).ToList();
             return Ok(publishedForms);
         }
 
-        // estatísticas simples (contagens)
         [HttpGet("stats")]
         public async Task<IActionResult> GetStats()
         {
-            var allForms = await _jsonHandler.GetAllFormsAsync();
-            var total = allForms?.Count ?? 0;
-            var published = allForms?.Count(f => !f.StatusDrafted) ?? 0;
-            var drafted = allForms?.Count(f => f.StatusDrafted) ?? 0;
+            var allForms = await _jsonHandler.GetAllFormsAsync() ?? [];
+            var published = allForms.Count(f => f.Status == FormStatus.Published);
+            var drafted = allForms.Count(f => f.Status == FormStatus.Draft);
+            var archived = allForms.Count(f => f.Status == FormStatus.Archived);
+            var total = published + drafted; // "ativos"
 
             return Ok(new
             {
                 totalForms = total,
                 publishedForms = published,
-                draftedForms = drafted
+                draftedForms = drafted,
+                archivedForms = archived
             });
         }
-
-
-
 
         [HttpGet("{id}")]
         public async Task<IActionResult> GetById(int id)
         {
-            // Carrega a lista completa de formulários guardados no ficheiro JSON.
             var allForms = await _jsonHandler.GetAllFormsAsync();
-
-            // Procura o formulário correspondente ao ID recebido.
             var form = allForms.FirstOrDefault(f => f.Id == id);
 
-            // Se não existir, devolve 404.
             if (form == null)
             {
                 return NotFound(new { message = $"Form with ID {id} not found." });
@@ -139,10 +150,7 @@ namespace Formify.Server.Controllers
         [HttpDelete("{id}")]
         public async Task<IActionResult> DeleteForm(int id)
         {
-            // Carrega os formulários existentes.
             var allForms = await _jsonHandler.GetAllFormsAsync();
-
-            // Procura o formulário a remover.
             var formToRemove = allForms.FirstOrDefault(f => f.Id == id);
 
             if (formToRemove == null)
@@ -156,6 +164,10 @@ namespace Formify.Server.Controllers
             return Ok(new { message = "Formulário eliminado com sucesso." });
         }
 
+        // PUT /api/forms/{id}
+        // Permite editar drafts e publicados. Edição de publicados incrementa
+        // Version, marcando submissões anteriores como desatualizadas.
+        // Não permite editar arquivados (devem ser reativados primeiro).
         [HttpPut("{id}")]
         public async Task<IActionResult> UpdateForm(int id, [FromBody] CreateFormRequest request)
         {
@@ -179,7 +191,6 @@ namespace Formify.Server.Controllers
                 return BadRequest(new { message = "O formulário deve conter pelo menos um campo." });
             }
 
-            // Carrega todos os formulários e procura o que tem o ID correspondente
             var allForms = await _jsonHandler.GetAllFormsAsync();
             var formToUpdate = allForms.FirstOrDefault(f => f.Id == id);
 
@@ -188,39 +199,110 @@ namespace Formify.Server.Controllers
                 return NotFound(new { message = $"Formulário com ID {id} não encontrado." });
             }
 
-            // Um formulário publicado não pode ser editado.
-            // A única transição permitida sobre um publicado é voltar a rascunho (StatusDraft = true).
-            if (!formToUpdate.StatusDrafted && !request.StatusDraft)
+            if (formToUpdate.Status == FormStatus.Archived)
             {
                 return StatusCode(403, new
                 {
-                    message = "Não é possível editar um formulário publicado. Mova-o primeiro para rascunho."
+                    message = "Não é possível editar um formulário arquivado. Reativa-o primeiro."
                 });
             }
 
-            // Atualiza os dados do formulário existente
             formToUpdate.Title = request.Title.Trim();
             formToUpdate.Description = request.Description?.Trim();
             formToUpdate.Audience = request.Audience;
-            formToUpdate.StatusDrafted = request.StatusDraft;
+            formToUpdate.Status = StatusFromRequest(request.StatusDraft);
             formToUpdate.UpdatedAt = DateTime.Now;
             formToUpdate.Fields = request.Fields;
+            formToUpdate.Version += 1;
 
-            // Guarda as alterações
             await _jsonHandler.SaveFormsAsync(allForms);
 
             return Ok(new { message = "Formulário atualizado com sucesso.", form = formToUpdate });
         }
 
+        // POST /api/forms/{id}/duplicate
+        // Cria uma cópia independente do formulário em modo rascunho.
+        [HttpPost("{id}/duplicate")]
+        public async Task<IActionResult> DuplicateForm(int id)
+        {
+            var allForms = await _jsonHandler.GetAllFormsAsync();
+            var original = allForms.FirstOrDefault(f => f.Id == id);
 
-        // Adiciona este método dentro da classe FormsController
+            if (original == null)
+            {
+                return NotFound(new { message = $"Formulário com ID {id} não encontrado." });
+            }
+
+            var copy = new Form
+            {
+                Id = allForms.Any() ? allForms.Max(f => f.Id) + 1 : 1,
+                Title = $"Cópia de {original.Title}",
+                Description = original.Description,
+                Audience = [.. original.Audience],
+                Status = FormStatus.Draft,
+                Version = 1,
+                CreatedAt = DateTime.Now,
+                UpdatedAt = DateTime.Now,
+                Fields = original.Fields.Select(f => new Field
+                {
+                    Id = f.Id,
+                    Type = f.Type,
+                    Label = f.Label,
+                    Required = f.Required,
+                    Placeholder = f.Placeholder,
+                    Order = f.Order,
+                    Width = f.Width,
+                    Options = f.Options != null ? [.. f.Options] : null,
+                    TableFixedRows = f.TableFixedRows,
+                    TableRowCount = f.TableRowCount
+                }).ToList()
+            };
+
+            allForms.Add(copy);
+            await _jsonHandler.SaveFormsAsync(allForms);
+
+            return CreatedAtAction(nameof(GetById), new { id = copy.Id }, copy);
+        }
+
+        // PATCH /api/forms/{id}/archive — passa o formulário para o estado Archived.
+        [HttpPatch("{id}/archive")]
+        public async Task<IActionResult> ArchiveForm(int id)
+        {
+            return await ChangeStatus(id, FormStatus.Archived, "Formulário arquivado.");
+        }
+
+        // PATCH /api/forms/{id}/unarchive — recupera um arquivado para Draft
+        // (estado mais seguro: o admin reabre, valida e republica).
+        [HttpPatch("{id}/unarchive")]
+        public async Task<IActionResult> UnarchiveForm(int id)
+        {
+            return await ChangeStatus(id, FormStatus.Draft, "Formulário recuperado para rascunho.");
+        }
+
+        private async Task<IActionResult> ChangeStatus(int id, FormStatus status, string message)
+        {
+            var allForms = await _jsonHandler.GetAllFormsAsync();
+            var form = allForms.FirstOrDefault(f => f.Id == id);
+
+            if (form == null)
+            {
+                return NotFound(new { message = $"Formulário com ID {id} não encontrado." });
+            }
+
+            form.Status = status;
+            form.UpdatedAt = DateTime.Now;
+            await _jsonHandler.SaveFormsAsync(allForms);
+
+            return Ok(new { message, form });
+        }
+
+        // POST /api/forms/{formId}/submissions
         [HttpPost("{formId}/submissions")]
         [Authorize]
         public async Task<IActionResult> SubmitForm(int formId, [FromBody] Dictionary<string, object> answers)
         {
             try
             {
-                // 1. Extrair o ID e o Cargo do Utilizador diretamente do TOKEN JWT de forma segura
                 var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
                 var userRoleClaim = User.FindFirst(ClaimTypes.Role)?.Value;
 
@@ -232,7 +314,6 @@ namespace Formify.Server.Controllers
                 int userId = int.Parse(userIdClaim);
                 string userRole = userRoleClaim.ToLower();
 
-                // 2. Procurar o formulário
                 var allForms = await _jsonHandler.GetAllFormsAsync();
                 var form = allForms.FirstOrDefault(f => f.Id == formId);
 
@@ -241,12 +322,16 @@ namespace Formify.Server.Controllers
                     return NotFound(new { message = $"Formulário com ID {formId} não encontrado." });
                 }
 
-                if (form.StatusDrafted)
+                if (form.Status != FormStatus.Published)
                 {
-                    return BadRequest(new { message = "Não é possível submeter respostas para um formulário em modo rascunho." });
+                    return BadRequest(new
+                    {
+                        message = form.Status == FormStatus.Archived
+                            ? "Este formulário foi arquivado e já não aceita novas submissões."
+                            : "Não é possível submeter respostas para um formulário em modo rascunho."
+                    });
                 }
 
-                // 3. Validação de Permissões com base no cargo extraído do Token
                 var allowedAudiences = form.Audience != null
                     ? form.Audience.Where(a => a != null).Select(a => a.ToLower()).ToList()
                     : new List<string>();
@@ -256,13 +341,13 @@ namespace Formify.Server.Controllers
                     return StatusCode(403, new { message = "Acesso negado. O teu cargo não tem permissão para preencher este formulário." });
                 }
 
-                // 4. Criar a Submissão
                 var submission = new Submission
                 {
                     FormId = formId,
-                    UserId = userId, // Seguro do token
+                    UserId = userId,
                     Answers = answers ?? new Dictionary<string, object>(),
-                    SubmittedAt = DateTime.Now
+                    SubmittedAt = DateTime.Now,
+                    FormVersion = form.Version
                 };
 
                 var allSubmissions = await _jsonHandler.GetAllSubmissionsAsync();
@@ -278,7 +363,3 @@ namespace Formify.Server.Controllers
         }
     }
 }
-
-
-
-  

--- a/backend/Formify/Formify.Server/Controllers/SubmissionsController.cs
+++ b/backend/Formify/Formify.Server/Controllers/SubmissionsController.cs
@@ -1,3 +1,4 @@
+using Formify.Server.Models;
 using Formify.Server.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -37,6 +38,9 @@ namespace Formify.Server.Controllers
                 .Select(s =>
                 {
                     var form = allForms.FirstOrDefault(f => f.Id == s.FormId);
+                    // "stale" = o formulário foi alterado depois desta submissão.
+                    var isStale = form != null && form.Version > s.FormVersion;
+                    var formArchived = form != null && form.Status == FormStatus.Archived;
                     return new
                     {
                         id = s.Id,
@@ -44,7 +48,11 @@ namespace Formify.Server.Controllers
                         formTitle = form?.Title ?? "(Formulário removido)",
                         formDescription = form?.Description,
                         submittedAt = s.SubmittedAt,
-                        status = "Submetido"
+                        status = "Submetido",
+                        formVersion = s.FormVersion,
+                        currentFormVersion = form?.Version,
+                        isStale,
+                        formArchived
                     };
                 })
                 .ToList();
@@ -80,6 +88,9 @@ namespace Formify.Server.Controllers
             var allForms = await _jsonHandler.GetAllFormsAsync();
             var form = allForms.FirstOrDefault(f => f.Id == submission.FormId);
 
+            var isStale = form != null && form.Version > submission.FormVersion;
+            var formArchived = form != null && form.Status == FormStatus.Archived;
+
             return Ok(new
             {
                 id = submission.Id,
@@ -87,7 +98,11 @@ namespace Formify.Server.Controllers
                 submittedAt = submission.SubmittedAt,
                 status = "Submetido",
                 answers = submission.Answers,
-                form
+                form,
+                formVersion = submission.FormVersion,
+                currentFormVersion = form?.Version,
+                isStale,
+                formArchived
             });
         }
 

--- a/backend/Formify/Formify.Server/Models/Form.cs
+++ b/backend/Formify/Formify.Server/Models/Form.cs
@@ -1,5 +1,12 @@
 namespace Formify.Server.Models
 {
+    public enum FormStatus
+    {
+        Draft,
+        Published,
+        Archived
+    }
+
     public class Form
     {
         public int Id { get; set; }
@@ -10,7 +17,15 @@ namespace Formify.Server.Models
 
         public List<string> Audience { get; set; } = new();
 
-        public bool StatusDrafted { get; set; }
+        // Estado único do formulário: Draft (rascunho), Published (disponível
+        // para preenchimento) ou Archived (retirado de circulação).
+        // Substituiu os antigos flags StatusDrafted + Archived.
+        public FormStatus Status { get; set; } = FormStatus.Draft;
+
+        // Versão do conteúdo do formulário. Incrementa sempre que o formulário
+        // é atualizado (PUT), para que submissões anteriores possam ser
+        // identificadas como associadas a uma versão antiga.
+        public int Version { get; set; } = 1;
 
         public List<Field> Fields { get; set; } = new List<Field>();
 

--- a/backend/Formify/Formify.Server/Models/Submission.cs
+++ b/backend/Formify/Formify.Server/Models/Submission.cs
@@ -12,5 +12,9 @@
         public Dictionary<string, object> Answers { get; set; } = new();
 
         public DateTime SubmittedAt { get; set; } = DateTime.Now;
+
+        // Versão do formulário no momento da submissão. Permite detetar se o
+        // formulário foi alterado depois da submissão (submissão desatualizada).
+        public int FormVersion { get; set; } = 1;
     }
 }

--- a/backend/Formify/Formify.Server/Program.cs
+++ b/backend/Formify/Formify.Server/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -20,6 +21,13 @@ if (builder.Environment.IsDevelopment())
 
 // Add services to the container.
 builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        // Enums (ex: FormStatus) serializam como string "Draft"/"Published"/"Archived"
+        // em vez de número, para ficarem legíveis no frontend e no JSON guardado.
+        options.JsonSerializerOptions.Converters.Add(
+            new JsonStringEnumConverter(allowIntegerValues: true));
+    })
     .ConfigureApiBehaviorOptions(options =>
     {
         options.InvalidModelStateResponseFactory = context =>

--- a/backend/Formify/Formify.Server/Services/JsonHandler.cs
+++ b/backend/Formify/Formify.Server/Services/JsonHandler.cs
@@ -1,10 +1,21 @@
-﻿using Formify.Server.Models;
+using Formify.Server.Models;
 using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 
 namespace Formify.Server.Services
 {
     public class JsonHandler
     {
+        // Serializer partilhado: enums escritos como string (ex: "Draft"),
+        // case-insensitive na leitura, output indentado.
+        private static readonly JsonSerializerOptions JsonOpts = new()
+        {
+            WriteIndented = true,
+            PropertyNameCaseInsensitive = true,
+            Converters = { new JsonStringEnumConverter(allowIntegerValues: true) }
+        };
+
         //Pode vir a dar jeito.
         private readonly string _filePathElements = Path.Combine(
             Directory.GetCurrentDirectory(),
@@ -41,8 +52,37 @@ namespace Formify.Server.Services
             try
             {
                 var json = await File.ReadAllTextAsync(_filePathList);
-                // Deserialize the list of forms from the file
-                return JsonSerializer.Deserialize<List<Form>>(json) ?? new List<Form>();
+                if (string.IsNullOrWhiteSpace(json)) return new List<Form>();
+
+                // Migração transparente: se algum form ainda tem `StatusDrafted`
+                // ou `Archived` em vez do novo campo `Status`, derivamos o valor.
+                var array = JsonNode.Parse(json) as JsonArray;
+                if (array == null) return new List<Form>();
+
+                bool needsResave = false;
+                foreach (var item in array.OfType<JsonObject>())
+                {
+                    if (item["Status"] == null && item["status"] == null)
+                    {
+                        var archived = (item["Archived"] ?? item["archived"])?.GetValue<bool>() ?? false;
+                        var drafted = (item["StatusDrafted"] ?? item["statusDrafted"])?.GetValue<bool>() ?? false;
+                        var status = archived ? "Archived" : drafted ? "Draft" : "Published";
+                        item["Status"] = status;
+                        item.Remove("Archived"); item.Remove("archived");
+                        item.Remove("StatusDrafted"); item.Remove("statusDrafted");
+                        needsResave = true;
+                    }
+                }
+
+                var forms = JsonSerializer.Deserialize<List<Form>>(array.ToJsonString(), JsonOpts)
+                            ?? new List<Form>();
+
+                if (needsResave)
+                {
+                    await SaveFormsAsync(forms);
+                }
+
+                return forms;
             }
             catch
             {
@@ -53,8 +93,7 @@ namespace Formify.Server.Services
 
         public async Task SaveFormsAsync(List<Form> forms)
         {
-            var options = new JsonSerializerOptions { WriteIndented = true };
-            var json = JsonSerializer.Serialize(forms, options);
+            var json = JsonSerializer.Serialize(forms, JsonOpts);
             await File.WriteAllTextAsync(_filePathList, json);
         }
 
@@ -68,7 +107,7 @@ namespace Formify.Server.Services
             try
             {
                 var json = await File.ReadAllTextAsync(_filePathSubmissions);
-                return JsonSerializer.Deserialize<List<Submission>>(json) ?? new List<Submission>();
+                return JsonSerializer.Deserialize<List<Submission>>(json, JsonOpts) ?? new List<Submission>();
             }
             catch
             {
@@ -78,8 +117,7 @@ namespace Formify.Server.Services
 
         public async Task SaveSubmissionsAsync(List<Submission> submissions)
         {
-            var options = new JsonSerializerOptions { WriteIndented = true };
-            var json = JsonSerializer.Serialize(submissions, options);
+            var json = JsonSerializer.Serialize(submissions, JsonOpts);
             await File.WriteAllTextAsync(_filePathSubmissions, json);
         }
     }

--- a/backend/Formify/formify.client/src/App.jsx
+++ b/backend/Formify/formify.client/src/App.jsx
@@ -25,8 +25,7 @@ export default function App() {
                     <Route path="/login" element={<Login />} />
                     <Route path="/register" element={<Register />} />
 
-                    <Route path="/admin" element={<ProtectedRoute allowedRoles={["admin"]}><AdminDashboard isDraft={false} /></ProtectedRoute>} />
-                    <Route path="/DraftedForms" element={<ProtectedRoute allowedRoles={["admin"]}><AdminDashboard isDraft={true} /></ProtectedRoute>} />
+                    <Route path="/admin" element={<ProtectedRoute allowedRoles={["admin"]}><AdminDashboard /></ProtectedRoute>} />
 
                     <Route path="/professor" element={<ProtectedRoute allowedRoles={["professor"]}><ProfessorDashboard /></ProtectedRoute>} />
 

--- a/backend/Formify/formify.client/src/components/Layout/Sidebar.jsx
+++ b/backend/Formify/formify.client/src/components/Layout/Sidebar.jsx
@@ -68,9 +68,6 @@ export default function Sidebar() {
             <Link to="/admin" className={linkCls}>
               Formulários
             </Link>
-            <Link to="/DraftedForms" className={linkCls}>
-              Formulários em Rascunho
-            </Link>
             <Link to="/CreateForm" className={linkCls}>
               Criar Formulário
             </Link>

--- a/backend/Formify/formify.client/src/pages/AdminDashboard.jsx
+++ b/backend/Formify/formify.client/src/pages/AdminDashboard.jsx
@@ -1,232 +1,143 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
-/**
- * AdminDashboard Component Unificado
- * Serve tanto para listar Formulários Publicados como Rascunhos.
- */
-export default function AdminDashboard({ isDraft = false }) {
+const TABS = [
+    { key: 'published', label: 'Publicados', emptyHint: 'Nenhum formulário publicado.' },
+    { key: 'draft', label: 'Rascunhos', emptyHint: 'Nenhum rascunho.' },
+    { key: 'archived', label: 'Arquivados', emptyHint: 'Sem formulários arquivados.' },
+];
+
+const normalizeText = (value) =>
+    (value || '').toString().toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '');
+
+const getStatus = (form) => (form.status || form.Status || 'Draft').toString().toLowerCase();
+
+const getAudienceList = (form) => {
+    const raw = form.audience || form.Audience || [];
+    return Array.isArray(raw) ? raw.map(normalizeText) : [normalizeText(raw)];
+};
+
+const matchesCargo = (form, cargo) => {
+    if (cargo === 'todos') return true;
+    const audience = getAudienceList(form);
+
+    const hasTeacher = audience.includes('teacher') || audience.includes('professor') || audience.includes('professores');
+    const hasStaff = audience.includes('staff') || audience.includes('funcionario') || audience.includes('funcionarios');
+
+    if (cargo === 'professores') return hasTeacher;
+    if (cargo === 'funcionarios') return hasStaff;
+    return true;
+};
+
+export default function AdminDashboard() {
+    const navigate = useNavigate();
+
+    // Tab ativa: 'published' | 'draft' | 'archived'
+    const [activeTab, setActiveTab] = useState('published');
+
     // Estatísticas (dados em tempo real do backend)
     const [stats, setStats] = useState({
         totalForms: 0,
         publishedForms: 0,
-        draftedForms: 0
+        draftedForms: 0,
+        archivedForms: 0,
     });
     const [isStatsLoading, setIsStatsLoading] = useState(true);
 
-    // Lista de formulários carregados a partir do backend
     const [forms, setForms] = useState([]);
-
-    // Estado de carregamento da página
     const [isLoading, setIsLoading] = useState(true);
 
-    // Filtros da listagem
     const [selectedCargo, setSelectedCargo] = useState('todos');
     const [searchTerm, setSearchTerm] = useState('');
     const [sortDate, setSortDate] = useState('newest');
-
-    // Mensagem de confirmação
-    const [confirmModal, setConfirmModal] = useState({
-        open: false,
-        id: null
-    });
-
-    // Paginação
     const [currentPage, setCurrentPage] = useState(1);
     const formsPerPage = 12;
 
-    const navigate = useNavigate();
+    const loadStats = async () => {
+        try {
+            setIsStatsLoading(true);
+            const res = await fetch('http://localhost:5208/api/Forms/stats');
+            if (!res.ok) throw new Error('Erro ao obter estatísticas');
+            const data = await res.json();
+            setStats(data);
+        } catch (err) {
+            console.error('Erro a carregar stats:', err);
+        } finally {
+            setIsStatsLoading(false);
+        }
+    };
 
-    // ─── Buscar estatísticas ───
+    const loadForms = async (tab) => {
+        try {
+            setIsLoading(true);
+            const response = await fetch(`http://localhost:5208/api/Forms?status=${tab}`);
+            if (!response.ok) throw new Error('Erro ao procurar formulários');
+            const data = await response.json();
+            setForms(data);
+        } catch (error) {
+            console.error('Erro na integração:', error);
+            setForms([]);
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
     useEffect(() => {
-        const fetchStats = async () => {
-            try {
-                setIsStatsLoading(true);
-                const res = await fetch('http://localhost:5208/api/Forms/stats');
-                if (!res.ok) throw new Error('Erro ao obter estatísticas');
-                const data = await res.json();
-                setStats(data);
-            } catch (err) {
-                console.error('Erro a carregar stats:', err);
-            } finally {
-                setIsStatsLoading(false);
-            }
-        };
-
-        fetchStats();
+        loadStats();
     }, []);
 
-    // Carrega os formulários quando a página é aberta
     useEffect(() => {
-        const fetchForms = async () => {
-            try {
-                setIsLoading(true);
-                const response = await fetch('http://localhost:5208/api/Forms');
+        loadForms(activeTab);
+        setCurrentPage(1);
+    }, [activeTab]);
 
-                if (!response.ok) {
-                    throw new Error('Erro ao procurar formulários');
-                }
+    const filteredAndSortedForms = useMemo(() => {
+        const filtered = forms
+            .filter((form) => matchesCargo(form, selectedCargo))
+            .filter((form) => {
+                const term = normalizeText(searchTerm.trim());
+                if (!term) return true;
 
-                const data = await response.json();
-                setForms(data);
-            } catch (error) {
-                console.error('Erro na integração:', error);
-            } finally {
-                setIsLoading(false);
-            }
-        };
+                const title = normalizeText(form.title || form.Title || '');
+                const description = normalizeText(form.description || form.Description || '');
+                const searchableText = `${title} ${description}`;
 
-        fetchForms();
-    }, []);
+                const tokens = term.split(/\s+/).filter(Boolean);
+                const words = searchableText.split(/[^a-z0-9]+/).filter(Boolean);
+                return tokens.every((token) => words.some((word) => word.startsWith(token)));
+            });
 
-    const normalizeText = (value) =>
-        (value || '')
-            .toString()
-            .toLowerCase()
-            .normalize('NFD')
-            .replace(/[\u0300-\u036f]/g, '');
-
-    // ─── Filtro Magno ───
-    // Verifica se o formulário corresponde ao separador atual (Rascunho vs Publicado)
-    const isTargetStatus = (form) => {
-        const statusDrafted = form.statusDrafted ?? form.StatusDrafted;
-        return statusDrafted === isDraft;
-    };
-
-    const getAudience = (form) => {
-        const rawAudience = form.audience || form.Audience || [];
-
-        if (Array.isArray(rawAudience)) {
-            return rawAudience.map(normalizeText);
-        }
-
-        return [normalizeText(rawAudience)];
-    };
-
-    const matchesCargo = (form) => {
-        if (selectedCargo === 'todos') return true;
-
-        const audience = getAudience(form);
-
-        const hasTeacher =
-            audience.includes('teacher') ||
-            audience.includes('professor') ||
-            audience.includes('professores');
-
-        const hasStaff =
-            audience.includes('staff') ||
-            audience.includes('funcionario') ||
-            audience.includes('funcionarios');
-
-        const hasBoth = hasTeacher && hasStaff;
-
-        if (selectedCargo === 'professores') {
-            return hasTeacher || hasBoth;
-        }
-
-        if (selectedCargo === 'funcionarios') {
-            return hasStaff || hasBoth;
-        }
-
-        return true;
-    };
-
-    const filteredForms = forms
-        .filter(isTargetStatus) // Agora filtra com base no isDraft!
-        .filter(matchesCargo)
-        .filter((form) => {
-            const term = normalizeText(searchTerm.trim());
-
-            if (!term) return true;
-
-            const title = normalizeText(form.title || form.Title || '');
-            const description = normalizeText(form.description || form.Description || '');
-            const searchableText = `${title} ${description}`;
-
-            const tokens = term.split(/\s+/).filter(Boolean);
-            const words = searchableText.split(/[^a-z0-9]+/).filter(Boolean);
-
-            return tokens.every((token) =>
-                words.some((word) => word.startsWith(token))
-            );
+        return [...filtered].sort((a, b) => {
+            const dateA = new Date(a.createdAt || a.CreatedAt || 0).getTime();
+            const dateB = new Date(b.createdAt || b.CreatedAt || 0).getTime();
+            return sortDate === 'oldest' ? dateA - dateB : dateB - dateA;
         });
-
-    const filteredAndSortedForms = [...filteredForms].sort((a, b) => {
-        const dateA = new Date(a.createdAt || a.CreatedAt || 0).getTime();
-        const dateB = new Date(b.createdAt || b.CreatedAt || 0).getTime();
-
-        if (sortDate === 'oldest') {
-            return dateA - dateB;
-        }
-
-        return dateB - dateA;
-    });
+    }, [forms, selectedCargo, searchTerm, sortDate]);
 
     const totalPages = Math.max(1, Math.ceil(filteredAndSortedForms.length / formsPerPage));
-    const indexOfLastForm = currentPage * formsPerPage;
-    const indexOfFirstForm = indexOfLastForm - formsPerPage;
-    const paginatedForms = filteredAndSortedForms.slice(indexOfFirstForm, indexOfLastForm);
-
-    // Repõe a página a 1 se mudarmos de separador (isDraft) ou alterarmos filtros
-    useEffect(() => {
-        setCurrentPage(1);
-    }, [searchTerm, selectedCargo, sortDate, isDraft]);
+    const paginatedForms = filteredAndSortedForms.slice(
+        (currentPage - 1) * formsPerPage,
+        currentPage * formsPerPage,
+    );
 
     useEffect(() => {
-        if (currentPage > totalPages) {
-            setCurrentPage(totalPages);
-        }
+        if (currentPage > totalPages) setCurrentPage(totalPages);
     }, [currentPage, totalPages]);
 
-    const confirmMoveToDraft = async () => {
-        const id = confirmModal.id;
+    useEffect(() => {
+        setCurrentPage(1);
+    }, [searchTerm, selectedCargo, sortDate]);
 
-        try {
-            const form = forms.find(f => (f.id === id || f.Id === id));
-
-            const response = await fetch(`http://localhost:5208/api/Forms/${id}`, {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({
-                    ...form,
-                    statusDrafted: true
-                }),
-            });
-
-            if (!response.ok) {
-                throw new Error('Erro ao atualizar formulário');
-            }
-
-            setForms((prev) =>
-                prev.map((f) =>
-                    (f.id === id || f.Id === id)
-                        ? { ...f, statusDrafted: true }
-                        : f
-                )
-            );
-
-            setConfirmModal({ open: false, id: null });
-
-        } catch (error) {
-            console.error(error);
-            alert('Erro ao mover para rascunho');
-        }
-    };
+    const removeFormFromList = (id) =>
+        setForms((prev) => prev.filter((f) => (f.id ?? f.Id) !== id));
 
     const handleDelete = async (id) => {
-        const confirmacao = window.confirm('Tens a certeza que queres eliminar este formulário?');
-
-        if (!confirmacao) return;
-
+        if (!window.confirm('Tens a certeza que queres eliminar este formulário?')) return;
         try {
-            const response = await fetch(`http://localhost:5208/api/Forms/${id}`, {
-                method: 'DELETE',
-            });
-
+            const response = await fetch(`http://localhost:5208/api/Forms/${id}`, { method: 'DELETE' });
             if (response.ok) {
-                setForms(forms.filter(form => form.id !== id && form.Id !== id));
+                removeFormFromList(id);
+                loadStats();
             } else {
                 alert('Erro ao eliminar formulário.');
             }
@@ -236,87 +147,116 @@ export default function AdminDashboard({ isDraft = false }) {
         }
     };
 
+    const handleDuplicate = async (id) => {
+        try {
+            const response = await fetch(`http://localhost:5208/api/Forms/${id}/duplicate`, { method: 'POST' });
+            if (!response.ok) throw new Error('Erro ao duplicar formulário');
+            const copy = await response.json();
+            alert(`Cópia criada em rascunho: "${copy.title || copy.Title}".`);
+            loadStats();
+            if (activeTab === 'draft') {
+                setForms((prev) => [copy, ...prev]);
+            }
+        } catch (error) {
+            console.error('Erro ao duplicar:', error);
+            alert('Não foi possível duplicar o formulário.');
+        }
+    };
+
+    const handleArchive = async (id) => {
+        if (!window.confirm('Tens a certeza que queres arquivar este formulário?')) return;
+        try {
+            const response = await fetch(`http://localhost:5208/api/Forms/${id}/archive`, { method: 'PATCH' });
+            if (!response.ok) throw new Error('Erro ao arquivar');
+            removeFormFromList(id);
+            loadStats();
+        } catch (error) {
+            console.error('Erro ao arquivar:', error);
+            alert('Não foi possível arquivar o formulário.');
+        }
+    };
+
+    const handleUnarchive = async (id) => {
+        if (!window.confirm('Reativar este formulário? Vai voltar para rascunhos para validação.')) return;
+        try {
+            const response = await fetch(`http://localhost:5208/api/Forms/${id}/unarchive`, { method: 'PATCH' });
+            if (!response.ok) throw new Error('Erro ao reativar');
+            removeFormFromList(id);
+            loadStats();
+        } catch (error) {
+            console.error('Erro ao reativar:', error);
+            alert('Não foi possível reativar o formulário.');
+        }
+    };
+
     return (
         <div className="min-h-[calc(100vh-140px)] space-y-8 flex flex-col">
-            {/* Cabeçalho da página */}
+            {/* Cabeçalho */}
             <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
                 <div>
-                    {/* Títulos dinâmicos baseados no state isDraft */}
-                    <h2 className="text-3xl font-bold text-text-h">{isDraft ? "Formulários em Rascunho" : "Formulários"}</h2>
-                    <p className="mt-2 text-lg text-text">
-                        {isDraft ? "Listagem dos formulários por concluir" : "Listagem dos formulários publicados"}
-                    </p>
+                    <h2 className="text-3xl font-bold text-text-h">Formulários</h2>
+                    <p className="mt-2 text-lg text-text">Gestão dos formulários da plataforma</p>
                 </div>
 
                 <Link
                     to="/CreateForm"
-                    className="inline-flex w-fit items-center justify-center rounded-md bg-green-600 px-5 py-2 font-semibold text-white transition-all hover:bg-green-700"
+                    className="inline-flex w-fit items-center justify-center rounded-md bg-accent px-5 py-2 font-semibold text-white transition-all hover:bg-emerald-700"
                 >
                     + Novo Formulário
                 </Link>
             </div>
 
-            {/* Blocos de estatísticas (A plataforma em números) */}
+            {/* Stats cards */}
             <div className="grid gap-4 sm:grid-cols-3">
-                <div className="rounded-lg border border-accent-border p-6 bg-white">
-                    <h3 className="text-sm font-medium text-text-h">Formulários no total</h3>
-                    <p className="text-xs text-text mt-1">A crescer com a atividade do IPT</p>
+                <StatCard label="Publicados" value={isStatsLoading ? '—' : stats.publishedForms} hint="Disponíveis para preenchimento" />
+                <StatCard label="Rascunhos" value={isStatsLoading ? '—' : stats.draftedForms} hint="Em preparação pela administração" accent="amber" />
+                <StatCard label="Arquivados" value={isStatsLoading ? '—' : stats.archivedForms} hint="Fora de circulação" accent="gray" />
+            </div>
 
-                    <div className="mt-4">
-                        <div className="text-3xl font-bold text-green-700">
-                            {isStatsLoading ? '—' : stats.totalForms}
-                        </div>
-                    </div>
-                </div>
-
-                <div className="rounded-lg border border-accent-border p-6 bg-white">
-                    <h3 className="text-sm font-medium text-text-h">Formulários publicados</h3>
-                    <p className="text-xs text-text mt-1">Disponíveis para preenchimento</p>
-
-                    <div className="mt-4">
-                        <div className="text-3xl font-bold text-green-700">
-                            {isStatsLoading ? '—' : stats.publishedForms}
-                        </div>
-                    </div>
-                </div>
-
-                <div className="rounded-lg border border-accent-border p-6 bg-white">
-                    <h3 className="text-sm font-medium text-text-h">Em rascunho</h3>
-                    <p className="text-xs text-text mt-1">Em preparação pela administração</p>
-
-                    <div className="mt-4">
-                        <div className="text-3xl font-bold text-amber-600">
-                            {isStatsLoading ? '—' : stats.draftedForms}
-                        </div>
-                    </div>
-                </div>
+            {/* Tabs */}
+            <div className="border-b border-accent-border">
+                <nav className="-mb-px flex flex-wrap gap-2">
+                    {TABS.map((tab) => {
+                        const isActive = activeTab === tab.key;
+                        return (
+                            <button
+                                key={tab.key}
+                                type="button"
+                                onClick={() => setActiveTab(tab.key)}
+                                className={`border-b-2 px-4 py-2 text-sm font-semibold transition-colors ${
+                                    isActive
+                                        ? 'border-accent text-accent'
+                                        : 'border-transparent text-text hover:border-accent-border hover:text-text-h'
+                                }`}
+                            >
+                                {tab.label}
+                            </button>
+                        );
+                    })}
+                </nav>
             </div>
 
             {/* Filtros */}
-            <div className="grid gap-4 sm:grid-cols-3 my-6">
+            <div className="grid gap-4 sm:grid-cols-3">
                 <div className="flex flex-col gap-2">
-                    <label htmlFor="search-form" className="font-medium text-text-h">
-                        Pesquisar
-                    </label>
+                    <label htmlFor="search-form" className="font-medium text-text-h">Pesquisar</label>
                     <input
                         id="search-form"
                         type="text"
                         value={searchTerm}
                         onChange={(e) => setSearchTerm(e.target.value)}
                         placeholder="Nome ou palavras-chave"
-                        className="rounded-md border border-accent-border bg-white p-2 focus:border-blue-500 focus:outline-none"
+                        className="rounded-md border border-accent-border bg-white p-2 focus:border-accent focus:outline-none"
                     />
                 </div>
 
                 <div className="flex flex-col gap-2">
-                    <label htmlFor="cargo-filter" className="font-medium text-text-h">
-                        Cargo
-                    </label>
+                    <label htmlFor="cargo-filter" className="font-medium text-text-h">Cargo</label>
                     <select
                         id="cargo-filter"
                         value={selectedCargo}
                         onChange={(e) => setSelectedCargo(e.target.value)}
-                        className="rounded-md border border-accent-border bg-white p-2 focus:border-blue-500 focus:outline-none"
+                        className="rounded-md border border-accent-border bg-white p-2 focus:border-accent focus:outline-none"
                     >
                         <option value="todos">Todos</option>
                         <option value="professores">Professores</option>
@@ -325,14 +265,12 @@ export default function AdminDashboard({ isDraft = false }) {
                 </div>
 
                 <div className="flex flex-col gap-2">
-                    <label htmlFor="date-sort" className="font-medium text-text-h">
-                        Data de criação
-                    </label>
+                    <label htmlFor="date-sort" className="font-medium text-text-h">Data de criação</label>
                     <select
                         id="date-sort"
                         value={sortDate}
                         onChange={(e) => setSortDate(e.target.value)}
-                        className="rounded-md border border-accent-border bg-white p-2 focus:border-blue-500 focus:outline-none"
+                        className="rounded-md border border-accent-border bg-white p-2 focus:border-accent focus:outline-none"
                     >
                         <option value="newest">Mais novos primeiro</option>
                         <option value="oldest">Mais velhos primeiro</option>
@@ -340,149 +278,157 @@ export default function AdminDashboard({ isDraft = false }) {
                 </div>
             </div>
 
-            {/* Secção de formulários */}
+            {/* Listagem */}
             <div className="rounded-lg flex-1 flex flex-col">
                 {isLoading ? (
-                    <div className="text-center py-12 text-text">
-                        A carregar formulários...
-                    </div>
+                    <div className="text-center py-12 text-text">A carregar formulários...</div>
                 ) : filteredAndSortedForms.length === 0 ? (
                     <div className="rounded-lg border-2 border-dashed border-accent-border bg-accent-bg px-8 py-12 text-center">
-                        <p className="text-xl font-semibold text-text-h">
-                            Nenhum formulário encontrado
-                        </p>
+                        <p className="text-xl font-semibold text-text-h">Nenhum formulário encontrado</p>
                         <p className="mt-2 text-text">
-                            Tenta ajustar os filtros ou cria um novo formulário.
+                            {TABS.find((t) => t.key === activeTab)?.emptyHint}
                         </p>
                     </div>
                 ) : (
                     <>
                         <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-                            {paginatedForms.map((form) => {
-                                const id = form.id || form.Id;
-                                const title = form.title || form.Title || 'Sem título';
-                                const description = form.description || form.Description || 'Sem descrição';
-
-                                return (
-                                    <div
-                                        key={id}
-                                        onClick={() => navigate(`/ViewForm/${id}`)}
-                                        className="group flex flex-col h-full rounded-lg border border-accent-border p-6 shadow-sm hover:shadow-md hover:border-green-300 transition-all cursor-pointer bg-white"
-                                    >
-                                        <div className="mb-3 flex items-start justify-between gap-3">
-                                            <h3 className="font-bold text-lg text-text-h group-hover:text-green-700 transition-colors">
-                                                {title}
-                                            </h3>
-
-                                            {/* Etiqueta Visual Dinâmica */}
-                                            {isDraft ? (
-                                                <span className="rounded-full bg-amber-50 px-2 py-1 text-[10px] font-bold uppercase tracking-wider text-amber-600 border border-amber-100">
-                                                    Rascunho
-                                                </span>
-                                            ) : (
-                                                <span className="rounded-full bg-green-50 px-2 py-1 text-[10px] font-bold uppercase tracking-wider text-green-700 border border-green-100">
-                                                    Publicado
-                                                </span>
-                                            )}
-                                        </div>
-
-                                        <p className="text-sm text-text mt-2 line-clamp-3 flex-grow">
-                                            {description}
-                                        </p>
-
-                                        <div className="mt-4 flex justify-end gap-4 border-t border-accent-border pt-4 mt-auto">
-                                            {isDraft ? (
-                                                <button
-                                                    onClick={(e) => {
-                                                        e.stopPropagation();
-                                                        navigate(`/edit-form/${id}`);
-                                                    }}
-                                                    className="flex items-center gap-1 text-sm font-semibold text-blue-600 transition-colors hover:text-blue-800"
-                                                >
-                                                    ✏️ Editar
-                                                </button>
-                                            ) : (
-                                                    <button
-                                                        onClick={(e) => {
-                                                            e.stopPropagation();
-                                                            setConfirmModal({ open: true, id });
-                                                        }}
-                                                        className="flex items-center gap-1 text-sm font-semibold text-yellow-600 transition-colors hover:text-yellow-800"
-                                                    >
-                                                        ↩️ Tornar Rascunho
-                                                    </button>
-                                            )}
-                                            <button
-                                                onClick={(e) => {
-                                                    e.stopPropagation();
-                                                    handleDelete(id);
-                                                }}
-                                                className="flex items-center gap-1 text-sm font-semibold text-red-500 transition-colors hover:text-red-700"
-                                            >
-                                                🗑️ Eliminar
-                                            </button>
-                                        </div>
-                                    </div>
-                                );
-                            })}
+                            {paginatedForms.map((form) => (
+                                <FormCard
+                                    key={form.id ?? form.Id}
+                                    form={form}
+                                    tab={activeTab}
+                                    onOpen={(id) => navigate(`/ViewForm/${id}`)}
+                                    onEdit={(id) => navigate(`/edit-form/${id}`)}
+                                    onDuplicate={handleDuplicate}
+                                    onArchive={handleArchive}
+                                    onUnarchive={handleUnarchive}
+                                    onDelete={handleDelete}
+                                />
+                            ))}
                         </div>
 
-                        {/* Paginação */}
-                        <div className="mt-auto pt-6 flex items-center justify-between">
-                            <button
-                                type="button"
-                                onClick={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
-                                disabled={currentPage === 1}
-                                className="rounded-md border border-accent-border px-4 py-2 disabled:cursor-not-allowed disabled:opacity-50"
-                            >
-                                Anterior
-                            </button>
-
-                            <span className="text-sm text-text">
-                                Página {currentPage} de {totalPages}
-                            </span>
-
-                            <button
-                                type="button"
-                                onClick={() => setCurrentPage((prev) => Math.min(totalPages, prev + 1))}
-                                disabled={currentPage === totalPages}
-                                className="rounded-md border border-accent-border px-4 py-2 disabled:cursor-not-allowed disabled:opacity-50"
-                            >
-                                Próxima
-                            </button>
-                        </div>
+                        {totalPages > 1 && (
+                            <div className="mt-auto pt-6 flex items-center justify-between">
+                                <button
+                                    type="button"
+                                    onClick={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
+                                    disabled={currentPage === 1}
+                                    className="rounded-md border border-accent-border px-4 py-2 disabled:cursor-not-allowed disabled:opacity-50"
+                                >
+                                    Anterior
+                                </button>
+                                <span className="text-sm text-text">Página {currentPage} de {totalPages}</span>
+                                <button
+                                    type="button"
+                                    onClick={() => setCurrentPage((prev) => Math.min(totalPages, prev + 1))}
+                                    disabled={currentPage === totalPages}
+                                    className="rounded-md border border-accent-border px-4 py-2 disabled:cursor-not-allowed disabled:opacity-50"
+                                >
+                                    Próxima
+                                </button>
+                            </div>
+                        )}
                     </>
                 )}
             </div>
-            {confirmModal.open && (
-                <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
-                    <div className="bg-white rounded-lg p-6 w-[90%] max-w-md shadow-lg">
-                        <h2 className="text-lg font-bold text-text-h">
-                            Confirmar ação
-                        </h2>
+        </div>
+    );
+}
 
-                        <p className="mt-2 text-text">
-                            Tens a certeza que queres mover este formulário para rascunho?
-                        </p>
+function StatCard({ label, value, hint, accent }) {
+    const valueClass =
+        accent === 'amber' ? 'text-amber-600'
+        : accent === 'gray' ? 'text-gray-600'
+        : 'text-accent';
+    return (
+        <div className="rounded-lg border border-accent-border p-6 bg-white">
+            <h3 className="text-sm font-medium text-text-h">{label}</h3>
+            <p className="text-xs text-text mt-1">{hint}</p>
+            <div className={`mt-4 text-3xl font-bold ${valueClass}`}>{value}</div>
+        </div>
+    );
+}
 
-                        <div className="mt-6 flex justify-end gap-3">
-                            <button
-                                onClick={() => setConfirmModal({ open: false, id: null })}
-                                className="px-4 py-2 rounded-md border border-gray-300 hover:bg-gray-100"
-                            >
-                                Cancelar
-                            </button>
+function FormCard({ form, tab, onOpen, onEdit, onDuplicate, onArchive, onUnarchive, onDelete }) {
+    const id = form.id ?? form.Id;
+    const title = form.title || form.Title || 'Sem título';
+    const description = form.description || form.Description || 'Sem descrição';
+    const status = getStatus(form);
 
-                            <button
-                                onClick={confirmMoveToDraft}
-                                className="px-4 py-2 rounded-md bg-yellow-500 text-white hover:bg-yellow-600"
-                            >
-                                Confirmar
-                            </button>
-                        </div>
-                    </div>
-                </div>
-            )}
+    const badge = {
+        published: 'bg-green-50 text-green-700 border-green-100',
+        draft: 'bg-amber-50 text-amber-700 border-amber-100',
+        archived: 'bg-gray-100 text-gray-600 border-gray-200',
+    }[status] || 'bg-gray-100 text-gray-600 border-gray-200';
+
+    const badgeLabel = { published: 'Publicado', draft: 'Rascunho', archived: 'Arquivado' }[status] || status;
+
+    const stop = (handler) => (e) => {
+        e.stopPropagation();
+        handler();
+    };
+
+    return (
+        <div
+            onClick={() => onOpen(id)}
+            className="group flex flex-col h-full rounded-lg border border-accent-border p-6 shadow-sm hover:shadow-md hover:border-accent transition-all cursor-pointer bg-white"
+        >
+            <div className="mb-3 flex items-start justify-between gap-3">
+                <h3 className="font-bold text-lg text-text-h group-hover:text-accent transition-colors">
+                    {title}
+                </h3>
+                <span className={`rounded-full px-2 py-1 text-[10px] font-bold uppercase tracking-wider border ${badge}`}>
+                    {badgeLabel}
+                </span>
+            </div>
+
+            <p className="text-sm text-text mt-2 line-clamp-3 flex-grow">{description}</p>
+
+            <div className="mt-4 flex flex-wrap justify-end gap-x-4 gap-y-2 border-t border-accent-border pt-4">
+                {tab === 'archived' ? (
+                    <>
+                        <button
+                            onClick={stop(() => onUnarchive(id))}
+                            className="text-sm font-semibold text-accent transition-colors hover:opacity-80"
+                        >
+                            ↺ Desarquivar
+                        </button>
+                        <button
+                            onClick={stop(() => onDelete(id))}
+                            className="text-sm font-semibold text-red-500 transition-colors hover:text-red-700"
+                        >
+                            Eliminar
+                        </button>
+                    </>
+                ) : (
+                    <>
+                        <button
+                            onClick={stop(() => onEdit(id))}
+                            className="text-sm font-semibold text-blue-600 transition-colors hover:text-blue-800"
+                        >
+                            Editar
+                        </button>
+                        <button
+                            onClick={stop(() => onDuplicate(id))}
+                            className="text-sm font-semibold text-text transition-colors hover:text-accent"
+                        >
+                            Duplicar
+                        </button>
+                        <button
+                            onClick={stop(() => onArchive(id))}
+                            className="text-sm font-semibold text-gray-600 transition-colors hover:text-gray-800"
+                        >
+                            Arquivar
+                        </button>
+                        <button
+                            onClick={stop(() => onDelete(id))}
+                            className="text-sm font-semibold text-red-500 transition-colors hover:text-red-700"
+                        >
+                            Eliminar
+                        </button>
+                    </>
+                )}
+            </div>
         </div>
     );
 }

--- a/backend/Formify/formify.client/src/pages/CreateForm.jsx
+++ b/backend/Formify/formify.client/src/pages/CreateForm.jsx
@@ -657,9 +657,10 @@ export default function CreateForm() {
 
                 const formDados = await response.json();
 
-                const isPublished = (formDados.statusDrafted ?? formDados.StatusDrafted) === false;
-                if (isPublished) {
-                    pushToast('error', 'Este formulário está publicado e não pode ser editado.');
+                // Arquivados só podem ser editados depois de reativados.
+                const status = (formDados.status || formDados.Status || '').toString().toLowerCase();
+                if (status === 'archived') {
+                    pushToast('error', 'Este formulário está arquivado. Reativa-o antes de o editares.');
                     navigate('/admin');
                     return;
                 }

--- a/backend/Formify/formify.client/src/pages/Funcionario/FuncionarioDashboard.jsx
+++ b/backend/Formify/formify.client/src/pages/Funcionario/FuncionarioDashboard.jsx
@@ -37,7 +37,7 @@ export default function FuncionarioDashboard() {
 
    
     const filteredForms = forms
-        .filter(form => (form.statusDrafted ?? form.StatusDrafted) === false)
+        .filter(form => ((form.status || form.Status || '').toString().toLowerCase()) === 'published')
         .filter(form => {
             const audienceData = JSON.stringify(form.audience || form.Audience || "");
             const audienceStr = normalizeText(audienceData);

--- a/backend/Formify/formify.client/src/pages/Landing.jsx
+++ b/backend/Formify/formify.client/src/pages/Landing.jsx
@@ -20,11 +20,11 @@ export default function Landing() {
                 if (!response.ok) throw new Error('Erro ao obter formulários');
 
                 const data = await response.json();
-                const total = Array.isArray(data) ? data.length : 0;
-                const drafts = Array.isArray(data)
-                    ? data.filter(f => (f.statusDrafted ?? f.StatusDrafted) === true).length
-                    : 0;
-                const published = total - drafts;
+                const list = Array.isArray(data) ? data : [];
+                const statusOf = (f) => (f.status || f.Status || '').toString().toLowerCase();
+                const drafts = list.filter((f) => statusOf(f) === 'draft').length;
+                const published = list.filter((f) => statusOf(f) === 'published').length;
+                const total = drafts + published;
 
                 setStats({ total, published, drafts });
             } catch (error) {

--- a/backend/Formify/formify.client/src/pages/MySubmissionDetail.jsx
+++ b/backend/Formify/formify.client/src/pages/MySubmissionDetail.jsx
@@ -16,12 +16,121 @@ const formatDate = (iso) => {
     }
 };
 
-const formatAnswer = (value) => {
-    if (value === null || value === undefined || value === '') return '—';
-    if (Array.isArray(value)) return value.join(', ');
-    if (typeof value === 'object') return JSON.stringify(value, null, 2);
-    return String(value);
-};
+const isEmpty = (value) =>
+    value === null ||
+    value === undefined ||
+    value === '' ||
+    (Array.isArray(value) && value.length === 0);
+
+function AnswerValue({ field, value }) {
+    const type = (field.type || field.Type || 'text').toLowerCase();
+
+    if (isEmpty(value)) {
+        return <p className="text-sm italic text-gray-400">Sem resposta</p>;
+    }
+
+    switch (type) {
+        case 'textarea':
+            return (
+                <p className="whitespace-pre-wrap text-sm text-text-h">
+                    {String(value)}
+                </p>
+            );
+
+        case 'checkbox': {
+            const items = Array.isArray(value) ? value : [value];
+            return (
+                <ul className="space-y-1">
+                    {items.map((item, i) => (
+                        <li key={i} className="flex items-center gap-2 text-sm text-text-h">
+                            <span
+                                className="flex h-4 w-4 items-center justify-center rounded border border-accent bg-accent text-[10px] text-white"
+                                aria-hidden="true"
+                            >
+                                ✓
+                            </span>
+                            {String(item)}
+                        </li>
+                    ))}
+                </ul>
+            );
+        }
+
+        case 'radio':
+        case 'dropdown':
+            return (
+                <span className="inline-flex items-center rounded-md bg-accent-bg px-3 py-1 text-sm font-medium text-accent">
+                    {String(value)}
+                </span>
+            );
+
+        case 'date': {
+            let formatted = String(value);
+            try {
+                const d = new Date(value);
+                if (!isNaN(d.getTime())) {
+                    formatted = d.toLocaleDateString('pt-PT');
+                }
+            } catch {
+                // mantém o valor original
+            }
+            return <p className="text-sm text-text-h">{formatted}</p>;
+        }
+
+        default:
+            return <p className="text-sm text-text-h">{String(value)}</p>;
+    }
+}
+
+function TableAnswer({ field, answers }) {
+    const columns = field.options || field.Options || [];
+    const rowCount = field.tableRowCount || field.TableRowCount || 1;
+    const fId = field.id || field.Id;
+
+    return (
+        <div className="overflow-x-auto rounded-lg border border-accent-border">
+            <table className="w-full border-collapse text-sm">
+                <thead className="bg-accent-bg/40">
+                    <tr>
+                        <th className="border-b border-accent-border px-3 py-2 text-center text-xs font-semibold text-text-h">
+                            Nº
+                        </th>
+                        {columns.map((col, i) => (
+                            <th
+                                key={i}
+                                className="border-b border-accent-border px-3 py-2 text-left text-xs font-semibold text-text-h"
+                            >
+                                {col}
+                            </th>
+                        ))}
+                    </tr>
+                </thead>
+                <tbody>
+                    {Array.from({ length: rowCount }).map((_, r) => (
+                        <tr key={r} className="border-b border-gray-100 last:border-b-0">
+                            <td className="px-3 py-2 text-center text-xs text-text">
+                                {r + 1}
+                            </td>
+                            {columns.map((_, c) => {
+                                const cellId = `${fId}-r${r}-c${c}`;
+                                const cell = answers[cellId];
+                                return (
+                                    <td key={c} className="px-3 py-2 text-sm text-text-h">
+                                        {isEmpty(cell) ? (
+                                            <span className="italic text-gray-400">—</span>
+                                        ) : (
+                                            String(cell)
+                                        )}
+                                    </td>
+                                );
+                            })}
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}
 
 export default function MySubmissionDetail() {
     const { id } = useParams();
@@ -70,25 +179,20 @@ export default function MySubmissionDetail() {
     const fields = data?.form?.fields || data?.form?.Fields || [];
     const answers = data?.answers || {};
 
-    // Constrói linhas (pergunta, resposta) percorrendo os campos do formulário pela
-    // ordem original. Para garantir cobertura, depois acrescenta respostas extra
-    // cuja chave não corresponda a nenhum campo conhecido.
-    const knownIds = new Set(fields.map((f) => f.id || f.Id));
-    const orderedRows = fields
-        .filter((f) => (f.type || f.Type) !== 'section')
-        .map((f) => {
-            const fid = f.id || f.Id;
-            return {
-                key: fid,
-                label: f.label || f.Label || fid,
-                value: answers[fid],
-            };
-        });
-    const extraRows = Object.entries(answers)
-        .filter(([k]) => !knownIds.has(k))
-        .map(([k, v]) => ({ key: k, label: k, value: v }));
+    // Respostas com chaves que não correspondem a nenhum campo do formulário
+    // (por ex. células de tabela, cujo id é "<fieldId>-r<x>-c<y>"). Estas
+    // ficam de fora do fluxo normal e só aparecem se houver respostas órfãs.
+    const fieldIds = new Set(fields.map((f) => f.id || f.Id));
+    const tableCellPrefixes = fields
+        .filter((f) => (f.type || f.Type) === 'table')
+        .map((f) => `${f.id || f.Id}-r`);
 
-    const rows = [...orderedRows, ...extraRows];
+    const orphanAnswers = Object.entries(answers).filter(([key]) => {
+        if (fieldIds.has(key)) return false;
+        // Ignora chaves de células de tabela conhecidas; já são renderizadas
+        // dentro do componente da tabela.
+        return !tableCellPrefixes.some((p) => key.startsWith(p));
+    });
 
     return (
         <div className="space-y-6">
@@ -118,34 +222,118 @@ export default function MySubmissionDetail() {
                                 </p>
                             )}
                         </div>
-                        <span className="inline-flex w-fit shrink-0 items-center gap-2 rounded-full bg-accent-bg px-3 py-1 text-sm font-semibold text-accent">
-                            {data.status || 'Submetido'}
-                        </span>
+                        <div className="flex shrink-0 flex-col items-start gap-2 sm:items-end">
+                            <span className="inline-flex w-fit items-center gap-2 rounded-full bg-accent-bg px-3 py-1 text-sm font-semibold text-accent">
+                                {data.status || 'Submetido'}
+                            </span>
+                            {data.isStale && (
+                                <span className="inline-flex w-fit items-center gap-2 rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-700">
+                                    Desatualizado
+                                </span>
+                            )}
+                            {data.formArchived && (
+                                <span className="inline-flex w-fit items-center gap-2 rounded-full border border-gray-200 bg-gray-100 px-3 py-1 text-xs font-semibold text-gray-700">
+                                    Arquivado
+                                </span>
+                            )}
+                        </div>
                     </div>
+
+                    {data.isStale && (
+                        <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
+                            <strong>Nota:</strong> este formulário foi alterado pelo administrador depois da tua
+                            submissão (versão atual <strong>{data.currentFormVersion}</strong>, versão da tua
+                            resposta <strong>{data.formVersion}</strong>). As perguntas e respostas mostradas em baixo
+                            podem não corresponder exatamente à versão atual do formulário.
+                        </div>
+                    )}
+
+                    {data.formArchived && (
+                        <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm text-gray-700">
+                            <strong>Nota:</strong> este formulário foi arquivado pelo administrador e já não está
+                            disponível para novas submissões. A tua resposta continua acessível como histórico.
+                        </div>
+                    )}
 
                     <div className="rounded-lg border border-accent-border bg-white p-4 text-sm text-text">
                         <span className="font-semibold text-text-h">Submetido a:</span>{' '}
                         {formatDate(data.submittedAt)}
                     </div>
 
-                    <div className="rounded-lg border border-accent-border bg-white shadow-sm">
-                        <h3 className="border-b border-accent-border px-6 py-4 text-lg font-bold text-text-h">
+                    {/* Respostas com o mesmo layout em grid do formulário original */}
+                    <div className="rounded-lg border border-accent-border bg-white p-6 shadow-sm sm:p-8">
+                        <h3 className="mb-6 border-b border-accent-border pb-4 text-lg font-bold text-text-h">
                             Respostas
                         </h3>
 
-                        {rows.length === 0 ? (
-                            <p className="px-6 py-8 text-center text-text">Esta submissão não tem respostas registadas.</p>
+                        {fields.length === 0 && orphanAnswers.length === 0 ? (
+                            <p className="py-4 text-center text-text">
+                                Esta submissão não tem respostas registadas.
+                            </p>
                         ) : (
-                            <dl className="divide-y divide-gray-100">
-                                {rows.map((row) => (
-                                    <div key={row.key} className="grid gap-1 px-6 py-4 sm:grid-cols-3 sm:gap-4">
-                                        <dt className="text-sm font-semibold text-text-h sm:col-span-1">{row.label}</dt>
-                                        <dd className="whitespace-pre-wrap text-sm text-text sm:col-span-2">
-                                            {formatAnswer(row.value)}
-                                        </dd>
+                            <div className="grid grid-cols-1 gap-x-8 gap-y-6 sm:grid-cols-2">
+                                {fields.map((field) => {
+                                    const type = (field.type || field.Type || 'text').toLowerCase();
+                                    const fId = field.id || field.Id;
+                                    const label = field.label || field.Label || fId;
+                                    const width = field.width || field.Width || 'full';
+                                    const isHalf = width === 'half' && type !== 'section';
+                                    const span = isHalf ? 'sm:col-span-1' : 'col-span-1 sm:col-span-2';
+
+                                    if (type === 'section') {
+                                        return (
+                                            <div key={fId} className="col-span-1 mt-4 sm:col-span-2">
+                                                <div className="flex items-center gap-4">
+                                                    <h4 className="whitespace-nowrap text-sm font-bold uppercase tracking-widest text-text-h">
+                                                        {label}
+                                                    </h4>
+                                                    <div className="h-px w-full bg-accent-border" />
+                                                </div>
+                                            </div>
+                                        );
+                                    }
+
+                                    return (
+                                        <div key={fId} className={`${span} flex flex-col gap-2`}>
+                                            <label className="text-sm font-semibold text-text-h">
+                                                {label}
+                                            </label>
+                                            {type === 'table' ? (
+                                                <TableAnswer field={field} answers={answers} />
+                                            ) : (
+                                                <div className="rounded-md border border-accent-border bg-accent-bg/30 p-3">
+                                                    <AnswerValue field={field} value={answers[fId]} />
+                                                </div>
+                                            )}
+                                        </div>
+                                    );
+                                })}
+
+                                {orphanAnswers.length > 0 && (
+                                    <div className="col-span-1 mt-6 border-t border-accent-border pt-6 sm:col-span-2">
+                                        <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-text">
+                                            Outras respostas
+                                        </p>
+                                        <dl className="space-y-2">
+                                            {orphanAnswers.map(([key, value]) => (
+                                                <div
+                                                    key={key}
+                                                    className="grid grid-cols-1 gap-1 sm:grid-cols-3 sm:gap-4"
+                                                >
+                                                    <dt className="text-sm font-semibold text-text-h">{key}</dt>
+                                                    <dd className="whitespace-pre-wrap text-sm text-text sm:col-span-2">
+                                                        {Array.isArray(value)
+                                                            ? value.join(', ')
+                                                            : typeof value === 'object'
+                                                                ? JSON.stringify(value)
+                                                                : String(value)}
+                                                    </dd>
+                                                </div>
+                                            ))}
+                                        </dl>
                                     </div>
-                                ))}
-                            </dl>
+                                )}
+                            </div>
                         )}
                     </div>
                 </>

--- a/backend/Formify/formify.client/src/pages/MySubmissions.jsx
+++ b/backend/Formify/formify.client/src/pages/MySubmissions.jsx
@@ -146,9 +146,27 @@ export default function MySubmissions() {
                                         <h3 className="font-bold text-lg text-text-h group-hover:text-accent transition-colors">
                                             {s.formTitle}
                                         </h3>
-                                        <span className="shrink-0 rounded-full bg-accent-bg px-3 py-1 text-xs font-semibold text-accent">
-                                            {s.status || 'Submetido'}
-                                        </span>
+                                        <div className="flex shrink-0 flex-col items-end gap-1">
+                                            <span className="rounded-full bg-accent-bg px-3 py-1 text-xs font-semibold text-accent">
+                                                {s.status || 'Submetido'}
+                                            </span>
+                                            {s.isStale && (
+                                                <span
+                                                    className="rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-amber-700 border border-amber-200"
+                                                    title="O formulário foi alterado desde a tua submissão"
+                                                >
+                                                    Desatualizado
+                                                </span>
+                                            )}
+                                            {s.formArchived && (
+                                                <span
+                                                    className="rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-gray-700 border border-gray-200"
+                                                    title="O formulário já não está disponível"
+                                                >
+                                                    Arquivado
+                                                </span>
+                                            )}
+                                        </div>
                                     </div>
 
                                     {s.formDescription && (

--- a/backend/Formify/formify.client/src/pages/Professor/ProfessorDashboard.jsx
+++ b/backend/Formify/formify.client/src/pages/Professor/ProfessorDashboard.jsx
@@ -36,7 +36,7 @@ export default function ProfessorDashboard() {
         (value || '').toString().toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
 
     const filteredForms = forms
-        .filter(form => (form.statusDrafted ?? form.StatusDrafted) === false)
+        .filter(form => ((form.status || form.Status || '').toString().toLowerCase()) === 'published')
         .filter(form => {
             const rawAudience = form.audience || form.Audience || [];
             const audienceArray = Array.isArray(rawAudience) ? rawAudience.map(normalizeText) : [normalizeText(rawAudience)];

--- a/backend/Formify/formify.client/src/pages/RespondForm.jsx
+++ b/backend/Formify/formify.client/src/pages/RespondForm.jsx
@@ -20,9 +20,13 @@ export default function RespondForm() {
 
                 const data = await response.json();
 
-                // Bloqueia rascunhos no Frontend
-                if (data.statusDrafted || data.StatusDrafted) {
-                    window.dispatchEvent(new CustomEvent('app:toast', { detail: { message: 'Este formulário não aceita respostas.', type: 'error' } }));
+                // Só formulários publicados aceitam respostas (não rascunhos nem arquivados)
+                const status = (data.status || data.Status || '').toString().toLowerCase();
+                if (status !== 'published') {
+                    const message = status === 'archived'
+                        ? 'Este formulário foi arquivado e já não aceita respostas.'
+                        : 'Este formulário não aceita respostas.';
+                    window.dispatchEvent(new CustomEvent('app:toast', { detail: { message, type: 'error' } }));
                     navigate(-1);
                     return;
                 }
@@ -111,7 +115,7 @@ export default function RespondForm() {
     const description = formData.description || formData.Description || '';
 
     return (
-        <div className="max-w-3xl mx-auto py-12 px-4 sm:px-6">
+        <div className="max-w-4xl mx-auto py-12 px-4 sm:px-6">
             <button
                 onClick={() => navigate(-1)}
                 className="mb-6 text-accent font-semibold hover:text-emerald-700 transition-colors"
@@ -133,17 +137,24 @@ export default function RespondForm() {
                     </div>
                 </header>
 
-                <form onSubmit={handleSubmit} className="space-y-8">
+                <form
+                    onSubmit={handleSubmit}
+                    className="grid grid-cols-1 gap-x-8 gap-y-8 sm:grid-cols-2"
+                >
                     {fields.map((field) => {
                         const type = field.type || field.Type;
                         const label = field.label || field.Label;
                         const fId = field.id || field.Id;
                         const req = field.required || field.Required;
                         const options = field.options || field.Options || [];
+                        const width = field.width || field.Width || 'full';
+                        const colSpan = width === 'half' && type !== 'section'
+                            ? 'sm:col-span-1'
+                            : 'col-span-1 sm:col-span-2';
 
                         if (type === 'section') {
                             return (
-                                <div key={fId} className="pt-6 border-t border-gray-100">
+                                <div key={fId} className="col-span-1 pt-6 border-t border-gray-100 sm:col-span-2">
                                     <h2 className="text-xl font-bold text-text-h">{label}</h2>
                                     {(field.description || field.Description) && (
                                         <p className="text-sm text-text mt-1">{field.description || field.Description}</p>
@@ -153,7 +164,7 @@ export default function RespondForm() {
                         }
 
                         return (
-                            <div key={fId} className="flex flex-col gap-2">
+                            <div key={fId} className={`${colSpan} flex flex-col gap-2`}>
                                 <label className="font-semibold text-text-h">
                                     {label} {req && <span className="text-red-500 ml-1">*</span>}
                                 </label>
@@ -270,7 +281,7 @@ export default function RespondForm() {
                         );
                     })}
 
-                    <div className="pt-8 border-t border-gray-100 flex justify-end">
+                    <div className="col-span-1 pt-8 border-t border-gray-100 flex justify-end sm:col-span-2">
                         <button
                             type="submit"
                             className="bg-accent text-white px-8 py-3 rounded-lg font-bold hover:bg-emerald-700 transition-colors shadow-sm hover:shadow"


### PR DESCRIPTION
## Sumário

Implementa as funcionalidades 1, 2 e 3 da sub-issue #181 — Duplicar formulários, Arquivar e identificar submissões desatualizadas — e aproveita para limpar a lógica de estados dos formulários, que estava confusa com 2 flags independentes (`StatusDrafted` + `Archived`).

### Modelo de dados unificado
- Substitui `StatusDrafted: bool` + `Archived: bool` por **um único `Status: FormStatus` (Draft | Published | Archived)** em `Form.cs`.
- Novo `Submission.FormVersion` + `Form.Version`. `Version` incrementa em cada `PUT`; submissões com `FormVersion < currentVersion` ficam marcadas como `isStale`.
- `JsonHandler` faz **migração automática** do `FormsList.json` legacy (deriva `Status` a partir de `StatusDrafted`/`Archived` e re-grava). Sem intervenção manual.
- `Program.cs` e `JsonHandler` configuram `JsonStringEnumConverter` — o JSON guarda `"Draft"/"Published"/"Archived"` em vez de números.

### Endpoints novos / alterados
- `POST /api/forms/{id}/duplicate` — cópia independente em rascunho, título `Cópia de <original>`.
- `PATCH /api/forms/{id}/archive` — passa para `Archived`.
- `PATCH /api/forms/{id}/unarchive` — recupera para `Draft` (estado mais seguro para revisão).
- `GET /api/forms?status=draft|published|archived` (mantém `onlyArchived`/`includeArchived` por compat).
- `GET /api/forms/stats` agora devolve também `archivedForms`.
- `PUT /api/forms/{id}` agora **permite editar publicados** (incrementa `Version`). Bloqueado apenas em arquivados.
- `POST /api/forms/{id}/submissions` aceita só `Published`; bloqueia archived/draft com mensagens distintas. Grava `FormVersion` na submissão.
- `GET /api/submissions/me` e `/me/{id}` devolvem `isStale`, `formArchived`, `formVersion`, `currentFormVersion`.

### Frontend
- **AdminDashboard reescrito** com 3 tabs `Publicados | Rascunhos | Arquivados`. Ações contextuais: Editar (volta!), Duplicar, Arquivar, Eliminar (ativos); Desarquivar, Eliminar (arquivados). Stats cards com 3 contagens.
- **Rota `/DraftedForms` removida** + item "Formulários em Rascunho" sai da sidebar admin.
- `MySubmissions` e `MySubmissionDetail` mostram badges `Desatualizado` (âmbar) e `Arquivado` (cinza) com banners explicativos.
- `MySubmissionDetail` reescrito para **respeitar o layout original do formulário** (grid 2 colunas, secções, larguras half/full, tabelas, checkboxes, radio).
- `RespondForm` aplicado o mesmo grid layout (estava desformatado).
- Landing, Professor/Funcionario dashboards e CreateForm migrados de `statusDrafted` para `status`.

### O que **não** entra (fica para os colegas)
- Categorização de formulários (funcionalidade 4).
- Filtragem por categoria nas listagens (funcionalidade 5).
- Role de Aluno (funcionalidade 6).

## Critérios de aceitação cobertos
