### PR TITLE
feat: adicionar ResponsibleUserId ao modelo de pedido (#161)

### DIFF
--- a/backend/Formify/Formify.Server/Controllers/FormsController.cs
+++ b/backend/Formify/Formify.Server/Controllers/FormsController.cs
@@ -255,6 +255,8 @@ namespace Formify.Server.Controllers
                 {
                     FormId = formId,
                     UserId = userId,
+                    // Herda o responsável atual do formulário (fica congelado nesta submissão).
+                    ResponsibleUserId = form.ResponsibleUserId,
                     Answers = answers ?? new Dictionary<string, object>(),
                     SubmittedAt = DateTime.Now,
                     FormVersion = form.Version

--- a/backend/Formify/Formify.Server/Controllers/SubmissionsController.cs
+++ b/backend/Formify/Formify.Server/Controllers/SubmissionsController.cs
@@ -58,6 +58,8 @@ namespace Formify.Server.Controllers
                     {
                         id = s.Id,
                         userId = s.UserId, // Added this so you know WHO submitted it
+                        submittedByUserId = s.UserId, // alias com nome explícito (Ref #161)
+                        responsibleUserId = s.ResponsibleUserId,
                         formId = s.FormId,
                         formTitle = form?.Title ?? "(Formulário removido)",
                         formDescription = form?.Description,
@@ -101,10 +103,11 @@ namespace Formify.Server.Controllers
                     {
                         id = s.Id,
                         formId = s.FormId,
+                        submittedByUserId = s.UserId,
+                        responsibleUserId = s.ResponsibleUserId,
                         formTitle = form?.Title ?? "(Formulário removido)",
                         formDescription = form?.Description,
                         submittedAt = s.SubmittedAt,
-                       // status = "Submetido",
                         formVersion = s.FormVersion,
                         currentFormVersion = form?.Version,
                         isStale,
@@ -155,6 +158,8 @@ namespace Formify.Server.Controllers
             {
                 id = submission.Id,
                 formId = submission.FormId,
+                submittedByUserId = submission.UserId,
+                responsibleUserId = submission.ResponsibleUserId,
                 submittedAt = submission.SubmittedAt,
                 status = submission.Status ?? "Pending",
                 answers = submission.Answers,

--- a/backend/Formify/Formify.Server/Models/Submission.cs
+++ b/backend/Formify/Formify.Server/Models/Submission.cs
@@ -6,7 +6,12 @@
 
         public int FormId { get; set; }
 
-        public int UserId { get; set; } // ID do utilizador que preencheu
+        public int UserId { get; set; } // ID do utilizador que preencheu (submittedByUserId)
+
+        // Responsável pelo pedido — herdado de Form.ResponsibleUserId no momento
+        // da submissão. Fica "congelado" nesta submissão mesmo que o responsável
+        // do formulário seja alterado depois.
+        public int? ResponsibleUserId { get; set; }
 
         // Dicionário para guardar as respostas: Key = ID ou Nome do Campo, Value = Resposta
         public Dictionary<string, object> Answers { get; set; } = new();


### PR DESCRIPTION
## Sumário

Implementa a sub-issue #161 — modelo de pedido submetido com ligação ao responsável.

A maior parte dos campos do modelo já existia (`Id`, `FormId`, `UserId`, `Status`, `SubmittedAt`, `Answers`, `FormVersion`). Faltava apenas a ligação ao responsável.

## Mudanças

### Modelo ([Submission.cs](backend/Formify/Formify.Server/Models/Submission.cs))
- Novo campo `int? ResponsibleUserId` (nullable — formulários podem não ter responsável definido).

### Backend ([FormsController.SubmitForm](backend/Formify/Formify.Server/Controllers/FormsController.cs))
- Ao criar uma nova `Submission`, copia `form.ResponsibleUserId` para `submission.ResponsibleUserId`. O responsável fica "congelado" no momento da submissão — se o admin alterar o responsável do formulário mais tarde, as submissões anteriores mantêm o original.

### API ([SubmissionsController.cs](backend/Formify/Formify.Server/Controllers/SubmissionsController.cs))
- `GET /api/submissions/admin`, `GET /me` e `GET /me/{id}` passam a devolver `responsibleUserId` e `submittedByUserId` (alias explícito do `userId`, alinhado com o naming sugerido na issue).

## Critérios de aceitação

- [x] O pedido guarda o formulário associado (`FormId`).
- [x] O pedido guarda o utilizador que submeteu (`UserId` / `submittedByUserId`).
- [x] O pedido guarda o responsável (`ResponsibleUserId`, herdado do form na altura da submissão).
- [x] O pedido guarda o estado atual (`Status`, default `Pending`).

## Compatibilidade

- Submissões antigas (sem `ResponsibleUserId` no JSON) ficam com `null` na deserialização — sem migração necessária, sem erro.
- O campo `UserId` continua a ser serializado com o mesmo nome; `submittedByUserId` é apenas um alias adicional na response para uso do frontend.

## Test plan

- [ ] Atribuir um responsável a um formulário no editor (já era possível antes).
- [ ] Submeter o formulário (Postman ou via UI): `POST /api/forms/{id}/submissions`.
- [ ] Verificar em `SubmissionsList.json` que a nova submissão tem `ResponsibleUserId` com o ID correto.
- [ ] `GET /api/submissions/me/{id}` devolve `responsibleUserId` e `submittedByUserId`.
- [ ] Alterar o responsável do formulário, submeter outra vez, e confirmar que a submissão anterior mantém o responsável antigo enquanto a nova tem o novo.

## Não inclui (fica para sub-issues seguintes)

- UI do frontend para mostrar/usar o responsável.
- Restringir aprovação só ao responsável (atualmente qualquer admin aprova).
